### PR TITLE
[FEAT] 이메일 인증 구현 #1

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
@@ -1,0 +1,56 @@
+package com.snackoverflow.toolgether.domain.user.controller;
+
+import com.snackoverflow.toolgether.domain.user.service.VerificationService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final VerificationService verificationService;
+
+    // 이메일 인증
+    @PostMapping("/send-verification-code")
+    public ResponseEntity<String> sendVerificationCode(@Validated @RequestBody EmailRequest request,
+                                                       HttpSession session) {
+        verificationService.sendEmailWithCode(request.email, session);
+        return ResponseEntity.ok().body("인증 코드가 발송되었습니다.");
+    }
+
+    // 이메일 인증 확인
+    @PostMapping("/verified-email")
+    public ResponseEntity<String> verifiedEmail(@RequestBody @Validated VerificationRequest request) {
+        verificationService.verifyEmail(request.getEmail(), request.code);
+        return ResponseEntity.status(201).body("이메일 인증에 성공하였습니다.");
+    }
+
+    public record EmailRequest(
+            @NotBlank(message = "이메일을 입력해 주세요")
+            @Email(message = "유효한 이메일 형식이 아닙니다")
+            String email) {
+    }
+
+    @Data
+    static class VerificationRequest {
+        @NotBlank(message = "이메일을 입력해 주세요")
+        @Email(message = "유효한 이메일 형식이 아닙니다")
+        private String email;
+
+        @NotBlank(message = "인증 코드를 입력해주세요")
+        @Size(min = 8, max = 8, message = "인증 코드는 8자리여야 합니다")
+        @Pattern(regexp = "^[A-Za-z0-9]{8}$", message = "영문 대소문자와 숫자 조합 8자리를 입력해주세요")
+        private String code;
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/VerificationData.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/VerificationData.java
@@ -1,0 +1,34 @@
+package com.snackoverflow.toolgether.domain.user.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class VerificationData {
+
+    private String email;
+    private String code;
+    private boolean verified;
+    private final LocalDateTime createdAt; // 생성 시간
+    private final int expirationMinutes;   // 유효 시간 (분 단위)
+
+    public VerificationData(String email, String code, boolean verified) {
+        this.email = email;
+        this.code = code;
+        this.verified = verified;
+        this.createdAt = LocalDateTime.now();
+        this.expirationMinutes = 15; //15분 고정
+    }
+
+    private int attemptCount = 0; // 이메일 인증 제한
+
+    public int incrementAttempt() {
+        return ++attemptCount;
+    }
+
+    // 인증 만료 여부 체크
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(createdAt.plusMinutes(expirationMinutes));
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/MailService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/MailService.java
@@ -1,0 +1,141 @@
+package com.snackoverflow.toolgether.domain.user.service;
+
+import com.snackoverflow.toolgether.global.exception.custom.mail.MailPreparationException;
+import com.snackoverflow.toolgether.global.exception.custom.mail.SmtpConnectionException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailAuthenticationException;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    // 전송자 이메일 application.yml 파일 설정
+    // 구글 이용 시 앱 비밀번호 발급 받고 yml 파일 [본인 이메일, 앱 비밀번호] 로 바꿔 주셔야 합니다!
+    @Value("${spring.mail.username}")
+    private String SENDER_EMAIL;
+
+    // 인증 이메일 생성
+    public MimeMessage createMail(String email, String code) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        // 발신자, 수신자, 제목 설정
+        helper.setFrom(SENDER_EMAIL);
+        helper.setTo(email);
+        helper.setSubject("Toolgether 회원 가입 - 이메일 인증");
+
+        // HTML 본문 생성
+        helper.setText(buildEmailTemplate(code), true); // HTML 컨텐츠로 설정
+
+        // 로고 이미지 삽입
+        // helper.addInline("logo", new ClassPathResource("static/images/logo.png"));
+
+        return message;
+    }
+
+    // 회원가입 인증 이메일 전송 용도
+    public void sendMail(MimeMessage prebuiltMessage) {
+        try {
+            javaMailSender.send(prebuiltMessage);
+        } catch (MailAuthenticationException | MailSendException e) {
+            handleMailExceptions(e, null);
+        }
+    }
+
+    // 유저에게 메일 발송하는 용도 -> 인증 메일 템플릿 적용 x, 개별적으로 필요하신 분은 사용하세요!
+    public void sendMail(String email, String content, boolean isHtml) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+        MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setTo(email);
+            helper.setText(content, isHtml); // HTML 여부 설정
+            javaMailSender.send(message);
+        } catch (MessagingException | MailAuthenticationException | MailSendException e) {
+            handleMailExceptions(e, email);
+        }
+    }
+
+    // 예외 처리 중앙화
+    private void handleMailExceptions(Exception e, String email) {
+        if (e instanceof MessagingException) {
+            throw new MailPreparationException("메일 구성 오류: " + e.getMessage(), e);
+        } else if (e instanceof MailAuthenticationException) {
+            throw new SmtpConnectionException("SMTP 인증 실패: " + e.getMessage(), e);
+        } else if (e instanceof MailSendException) {
+            log.error("전송 실패 - 수신자: {} | 오류: {}", email, ((MailSendException) e).getFailedMessages());
+            throw new SmtpConnectionException("SMTP 연결 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private String buildEmailTemplate(String code) {
+        return """
+        <!DOCTYPE html>
+        <html lang="ko">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Toolgether 이메일 인증</title>
+        </head>
+        <body style="margin: 0; padding: 20px; font-family: 'Apple SD Gothic Neo', '맑은 고딕', Arial, sans-serif; background-color: #f4f9fd;">
+            <div style="max-width: 600px; margin: 0 auto; padding: 30px; background: white; border-radius: 12px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
+        
+                <!-- 헤더 섹션 -->
+                <header style="text-align: center; padding-bottom: 25px; border-bottom: 2px solid #e0f0e9;">
+                    <h1 style="color: #28a745; font-size: 28px; margin: 0 0 15px 0;">
+                        🌱 Toolgether 이메일 인증
+                    </h1>
+                    <p style="font-size: 16px; color: #555; line-height: 1.6; margin: 0;">
+                        안녕하세요! <strong style="color: #2c8c4a;">소유에서 공유로</strong>의 가치를 실현하는<br>
+                        <span style="background: linear-gradient(120deg, #28a745, #90d26d); -webkit-background-clip: text; color: transparent; font-weight: 700;">
+                            Toolgether
+                        </span> 팀입니다.<br>
+                        🔄 <em>구매 대신 이웃과 공유</em>하는 지속 가능한 라이프스타일을 함께 만들어가요!
+                    </p>
+                </header>
+
+                <!-- 본문 섹션 -->
+                <main style="padding: 25px 0;">
+                    <div style="padding: 25px; background: #eafce4; border-radius: 12px; border: 1px dashed #90d26d;">
+                        <p style="font-size: 14px; color: #4a7c59; margin: 0 0 12px 0;">
+                            🚨 아래 코드를 입력해 주세요
+                        </p>
+                        <div style="font-size: 36px; color: #28a745; font-weight: 800; letter-spacing: 2px; margin: 15px 0;">
+                            %s
+                        </div>
+                        <div style="font-size: 14px; color: #666;">
+                            ⏳ 유효 시간: <strong>15분</strong>
+                        </div>
+                    </div>
+                </main>
+
+                <!-- 푸터 섹션 -->
+                <footer style="margin-top: 30px; text-align: center; color: #888; font-size: 14px;">
+                    <hr style="border: none; border-top: 1px solid #e0f0e9; margin: 20px 0;">
+                    <p style="margin: 8px 0;">
+                        💬 문의: 
+                        <a href="mailto:support@toolgether.com" 
+                           style="color: #28a745; text-decoration: none; font-weight: 500;">
+                            support@toolgether.com
+                        </a>
+                    </p>
+                    <p style="margin: 8px 0;">
+                        ♻️ 2025 Toolgether - 지구를 위한 작은 변화
+                    </p>
+                </footer>
+            </div>
+        </body>
+        </html>
+        """.formatted(code); // 코드 동적 삽입
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/VerificationService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/VerificationService.java
@@ -1,0 +1,103 @@
+package com.snackoverflow.toolgether.domain.user.service;
+
+import com.snackoverflow.toolgether.domain.user.dto.VerificationData;
+import com.snackoverflow.toolgether.global.exception.custom.mail.MailPreparationException;
+import com.snackoverflow.toolgether.global.exception.custom.mail.VerificationException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+    private final HttpSession session;
+    private final MailService mailService;
+
+    public static final String SESSION_KEY = "email_verification";
+    private static final int MAX_ATTEMPTS = 5; // 이메일 인증 횟수 제한
+
+    // 8자리 랜덤 인증 코드 생성 (영어 대소문자 + 숫자)
+    public String createCode() {
+        Random random = new Random();
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < 8; i++) {
+            int index = random.nextInt(3);
+            switch (index) {
+                case 0 -> code.append((char) (random.nextInt(26) + 97)); // 소문자
+                case 1 -> code.append((char) (random.nextInt(26) + 65)); // 대문자
+                case 2 -> code.append(random.nextInt(10));              // 숫자
+            }
+        }
+        return code.toString();
+    }
+
+    // 이메일 인증을 위해 세션에 인증 정보를 저장
+    @Async // 비동기 처리 -> 이메일 발송 시간 단축, 시스템 성능 개선
+    public void sendEmailWithCode(String email, HttpSession session) {
+        // 인증 코드 생성
+        String code = createCode();
+
+        try {
+            // 인증 코드가 포함된 메일 생성
+            MimeMessage message = mailService.createMail(email, code);
+
+            // 메일 발송
+            mailService.sendMail(message);
+
+            // 세션에 저장
+            session.setAttribute(SESSION_KEY, new VerificationData(email.trim(), code, false));
+            session.setMaxInactiveInterval(60 * 15); // 15분 유효시간
+
+            log.info("세션 저장 성공: email={}, code={}", email, code);
+
+        } catch (MessagingException e) {
+            throw new MailPreparationException("메일 구성 오류: " + e.getMessage(), e); // 이메일 형식, 제목/본문 인코딩 문제
+        }
+    }
+
+    // 인증 코드 확인 후 세션 상태 변경 verified: false -> true
+    public void verifyEmail(String inputEmail, String inputCode) {
+        VerificationData data = (VerificationData) session.getAttribute(SESSION_KEY);
+
+        log.info("세션 이메일: {}, 요청 이메일: {}", data.getEmail(), inputEmail);
+        log.info("세션 인증 코드: {}, 요청 인증 코드: {}", data.getCode(), inputCode);
+
+        // 세션 데이터 검증 -> 저장된 데이터가 있는가?
+        if (data == null) {
+            throw new VerificationException(VerificationException.ErrorType.REQUEST_NOT_FOUND, "인증 요청이 존재하지 않습니다.");
+        }
+
+        // 세션에 저장된 이메일 일치 여부 확인
+        if (!data.getEmail().trim().equals(inputEmail.trim())) {
+            throw new VerificationException(VerificationException.ErrorType.REQUEST_NOT_FOUND, "요청 이메일 불일치: 세션 = "
+                    + data.getEmail() + " / 입력 = " + inputEmail);
+        }
+
+        // 코드 검증
+        if (!data.getCode().equals(inputCode)) {
+            throw new VerificationException(VerificationException.ErrorType.CODE_MISMATCH, "인증 코드 오류! 남은 시도 횟수: " + (MAX_ATTEMPTS - data.incrementAttempt()));
+        }
+
+        // 인증 만료 이전인지 검증
+        if (data.isExpired()) {
+            throw new VerificationException(VerificationException.ErrorType.EXPIRED, "인증 시간이 만료되었습니다. 재전송 후 시도해 주세요.");
+        }
+
+        data.setVerified(true);
+        session.setAttribute(SESSION_KEY, data);
+    }
+
+    // 세션으로 이메일 인증 여부 확인
+    public boolean isEmailVerified(String email) {
+        VerificationData data = (VerificationData) session.getAttribute(SESSION_KEY);
+        return data != null && data.getEmail().equals(email);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/AsyncConfig.java
@@ -1,0 +1,58 @@
+package com.snackoverflow.toolgether.global.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.concurrent.Executor;
+
+import static com.snackoverflow.toolgether.domain.user.service.VerificationService.SESSION_KEY;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10); // 기본 스레드 수
+        executor.setMaxPoolSize(30); // 최대 스레드 수
+        executor.setQueueCapacity(50); // 대기 큐 크기
+        executor.setThreadNamePrefix("Async-"); // 스레드 이름 식별자
+        executor.setTaskDecorator(new SessionAwareTaskDecorator());
+        executor.initialize(); // 초기화
+        return executor;
+    }
+
+    // 세션 복제 데코레이터
+    public class SessionAwareTaskDecorator implements TaskDecorator {
+        @Override
+        public Runnable decorate(Runnable runnable) {
+            HttpServletRequest request =
+                    ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+            HttpSession session = request.getSession(false);
+
+            return () -> {
+                try {
+                    RequestContextHolder.setRequestAttributes(
+                            new ServletRequestAttributes(request)
+                    );
+                    if (session != null) {
+                        request.getSession().setAttribute(SESSION_KEY, session.getAttribute(SESSION_KEY));
+                    }
+                    runnable.run();
+                } finally {
+                    RequestContextHolder.resetRequestAttributes();
+                }
+            };
+        }
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/MailException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/MailException.java
@@ -1,0 +1,8 @@
+package com.snackoverflow.toolgether.global.exception.custom.mail;
+
+// 메일 예외 베이스 클래스
+public abstract class MailException extends RuntimeException {
+    public MailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/MailPreparationException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/MailPreparationException.java
@@ -1,0 +1,8 @@
+package com.snackoverflow.toolgether.global.exception.custom.mail;
+
+// 메일 구성 오류
+public class MailPreparationException extends MailException {
+    public MailPreparationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/SmtpConnectionException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/SmtpConnectionException.java
@@ -1,0 +1,8 @@
+package com.snackoverflow.toolgether.global.exception.custom.mail;
+
+// SMTP 연결 오류
+public class SmtpConnectionException extends MailException {
+    public SmtpConnectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/VerificationException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/mail/VerificationException.java
@@ -1,0 +1,21 @@
+package com.snackoverflow.toolgether.global.exception.custom.mail;
+
+import lombok.Getter;
+
+@Getter
+public class VerificationException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    public VerificationException(ErrorType errorType, String message) {
+        super(message);
+        this.errorType = errorType;
+    }
+
+    public enum ErrorType {
+        REQUEST_NOT_FOUND, // 요청을 찾을 수 없음
+        CODE_MISMATCH, // 코드가 일치하지 않음
+        EXPIRED, // 만료된 인증 정보
+        NOT_VERIFIED // 이메일이 인증되지 않음
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.snackoverflow.toolgether.global.exception.handler;
+
+import com.snackoverflow.toolgether.global.exception.custom.mail.MailPreparationException;
+import com.snackoverflow.toolgether.global.exception.custom.mail.SmtpConnectionException;
+import com.snackoverflow.toolgether.global.exception.custom.mail.VerificationException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    static class ErrorResponse {
+        private String code;
+        private String message;
+        private LocalDateTime time;
+
+        public static ErrorResponse of(String code, String message) {
+            return ErrorResponse.builder()
+                    .code(code)
+                    .message(message)
+                    .time(LocalDateTime.now())
+                    .build();
+        }
+    }
+
+    @ExceptionHandler(MailPreparationException.class)
+    public ResponseEntity<ErrorResponse> handleMailPrep(MailPreparationException exception) {
+        return ResponseEntity.status(400)
+                .body(ErrorResponse.of("MAIL 400-1", exception.getMessage()));
+    }
+
+    @ExceptionHandler(SmtpConnectionException.class)
+    public ResponseEntity<ErrorResponse> handleMailPrep(SmtpConnectionException exception) {
+        return ResponseEntity.status(500)
+                .body(ErrorResponse.of("MAIL 500-1", exception.getMessage()));
+    }
+
+    @ExceptionHandler(VerificationException.class)
+    public ResponseEntity<ErrorResponse> handleVerification(VerificationException exception) {
+        return switch (exception.getErrorType()) {
+            case REQUEST_NOT_FOUND ->
+                    ResponseEntity.status(404).body(ErrorResponse.of("EMAIL-AUTH-404", exception.getMessage()));
+            case CODE_MISMATCH ->
+                    ResponseEntity.status(409).body(ErrorResponse.of("EMAIL-AUTH-409", exception.getMessage()));
+            case EXPIRED -> ResponseEntity.status(410).body(ErrorResponse.of("EMAIL-AUTH-410", exception.getMessage()));
+            case NOT_VERIFIED ->
+                    ResponseEntity.status(400).body(ErrorResponse.of("EMAIL-AUTH-400", exception.getMessage()));
+        };
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
+        return ResponseEntity.status(400).body(ErrorResponse.of("INVALID_ARGUMENT", exception.getMessage()));
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 server:
   port: 8080
+  servlet:
+    session:
+      timeout: 15m
 
 spring:
   jackson:
@@ -30,8 +33,17 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
-        default_batch_fetch_size: 10
-    #open-in-view: false
+        default_batch_fetch_size: 100
+    open-in-view: false
+
+  mail:
+    username: [본인 이메일 작성]
+    password: [앱 비밀번호 변경]
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
 
 logging:
   level:


### PR DESCRIPTION
## ✅ Check List
- 코드에 주석 / 로그 달았습니다
- 메일 전송 비동기 처리하기 위해 스레드 풀 설정
- 사용자가 이메일 인증을 받은 후에 가입할 수 있도록 설정 (중복 회원 방지)
- 이메일 인증을 하지 않은 사용자는 가입 불가

## 🔍 Test 

<img width="628" alt="스크린샷 2025-03-05 오후 12 36 43" src="https://github.com/user-attachments/assets/2719fe2c-9187-4adb-bd99-3153a0c05b47" />

![스크린샷 2025-03-05 오후 2 34 19](https://github.com/user-attachments/assets/258f4a5b-12d1-41ea-90ab-d3008732a47d)


<img width="573" alt="스크린샷 2025-03-05 오후 12 36 46" src="https://github.com/user-attachments/assets/75c184c8-bb5a-4aea-b270-25823de979e7" />

![스크린샷 2025-03-05 오후 12 36 28](https://github.com/user-attachments/assets/ca914e2e-0be8-4099-9a31-85ecdfdd1661)


## 🔗 Related Issues 
[[FEAT] 이메일 인증 구현 #1 ](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/1)

## 📝 Note (주의 사항) 
추후 오류 처리 message.properties 이용해서 바꿀 거고, 오류 부분도 조금 더 깔끔하게 리팩토링 해야 할 것 같아요 🥹
application.yml 파일에서 **본인 구글 이메일, 구글에서 발급 받은 앱 비밀번호** 추가해 주시면 인증 메일 본인에게 전송되고 코드도 확인 가능합니다!