### PR TITLE
[FEAT] 회원 가입 백엔드 로직 추가

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.snackoverflow.toolgether.domain.user.controller;
 
+import com.snackoverflow.toolgether.domain.user.dto.SignupRequest;
+import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.domain.user.service.VerificationService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.constraints.Email;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
 
+    private final UserService userService;
     private final VerificationService verificationService;
 
     // 이메일 인증
@@ -34,6 +37,17 @@ public class UserController {
     public ResponseEntity<String> verifiedEmail(@RequestBody @Validated VerificationRequest request) {
         verificationService.verifyEmail(request.getEmail(), request.code);
         return ResponseEntity.status(201).body("이메일 인증에 성공하였습니다.");
+    }
+
+    // 회원 가입
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody @Validated SignupRequest request) {
+        // 이메일, 아이디, 닉네임 중복 확인
+        userService.checkDuplicates(request);
+
+        // 이상 없을 시에 회원 가입 진행
+        userService.registerVerifiedUser(request);
+        return ResponseEntity.status(201).body("회원 가입이 완료되었습니다.");
     }
 
     public record EmailRequest(

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/SignupRequest.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/SignupRequest.java
@@ -1,0 +1,31 @@
+package com.snackoverflow.toolgether.domain.user.dto;
+
+import com.snackoverflow.toolgether.domain.user.entity.Address;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class SignupRequest {
+
+    @NotBlank(message = "사용자 id를 입력해주세요")
+    @Size(min = 8, max = 20, message = "사용자 id는 8~20자로 입력해주세요")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    // @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 영문+숫자 조합 8자 이상이어야 합니다")
+    private String password;
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "전화번호를 입력해주세요 [하이픈 제외]")
+    private String phoneNumber;
+
+    private String nickname;
+    private Address address;
+    private Double latitude; // 위도
+    private Double longitude; // 경도
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.snackoverflow.toolgether.domain.user.repository;
+
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
+
+    boolean existsByUsername(String username);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -1,0 +1,61 @@
+package com.snackoverflow.toolgether.domain.user.service;
+
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import com.snackoverflow.toolgether.domain.user.dto.SignupRequest;
+import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
+import com.snackoverflow.toolgether.global.exception.custom.duplicate.DuplicateFieldException;
+import com.snackoverflow.toolgether.global.exception.custom.mail.VerificationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final VerificationService verificationService;
+
+    // 이메일, 아이디, 닉네임 중복 방지
+    public void checkDuplicates(SignupRequest request) {
+        if (userRepository.existsByUsername(request.getUsername())) {
+            throw new DuplicateFieldException("사용자 ID 중복 오류 발생");
+        }
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateFieldException("사용자 EMAIL 중복 오류 발생");
+        }
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new DuplicateFieldException("사용자 닉네임 중복 오류 발생");
+        }
+    }
+
+    // 회원 가입
+    public void registerVerifiedUser(SignupRequest request) {
+        // 이메일 인증 완료 시 회원 가입 허용
+        if (!verificationService.isEmailVerified(request.getEmail())) {
+            throw new VerificationException(VerificationException.ErrorType.NOT_VERIFIED, "인증되지 않은 이메일입니다. 이메일: "+ request.getEmail());
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        //User 엔티티 생성 후 DB 저장
+        User user = User.builder()
+                .username(request.getUsername())
+                .password(request.getPassword())
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .address(request.getAddress())
+                .longitude(request.getLongitude())
+                .latitude(request.getLatitude())
+                .phoneNumber(request.getPhoneNumber())
+                .profileImage(null)
+                .build();
+
+        userRepository.save(user);
+    }
+
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/duplicate/DuplicateFieldException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/duplicate/DuplicateFieldException.java
@@ -1,0 +1,7 @@
+package com.snackoverflow.toolgether.global.exception.custom.duplicate;
+
+public class DuplicateFieldException extends RuntimeException{
+    public DuplicateFieldException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.snackoverflow.toolgether.global.exception.handler;
 
+import com.snackoverflow.toolgether.global.exception.custom.duplicate.DuplicateFieldException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.MailPreparationException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.SmtpConnectionException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.VerificationException;
@@ -62,5 +63,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException exception) {
         return ResponseEntity.status(400).body(ErrorResponse.of("INVALID_ARGUMENT", exception.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicateFieldException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateField(DuplicateFieldException exception) {
+        return ResponseEntity.status(409).body(ErrorResponse.of(
+                "FIELD-CONFLICT-409", exception.getMessage()));
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/init/TestDataInitializer.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/init/TestDataInitializer.java
@@ -1,0 +1,38 @@
+package com.snackoverflow.toolgether.global.init;
+
+import com.snackoverflow.toolgether.domain.user.entity.Address;
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestDataInitializer {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostConstruct
+    public void init() {
+        userRepository.deleteAll();
+        String encoded = passwordEncoder.encode("test1111");
+        User testUser = User.builder()
+                .username("exampleTest1")
+                .password(encoded)
+                .email("exampleForTest@gmail.com")
+                .phoneNumber("01012345678")
+                .nickname("성수동거주민")
+                .address(Address.builder()
+                        .mainAddress("서울시 성동구 성수동")
+                        .detailAddress("성수아파트 101동 202호")
+                        .zipcode("04700")
+                        .build())
+                .latitude(37.544579)
+                .longitude(127.055961)
+                .build();
+        userRepository.save(testUser);
+    }
+}


### PR DESCRIPTION
## ✅ Check List
- 코드에 주석 추가 완료
- 회원 가입 로직 구현
- 주소 비교 로직은 프론트에서 해결한 후에 저장할 예정
- 유저 테스트 데이터 하나 추가했습니다 추후 로그인 시도할 때 데이터로 활용하셔도 될 것 같아요
- h2 데이터베이스 연동해서 테스트 중 (개발 중에는 h2 이용하겠습니다)

![스크린샷 2025-03-05 오후 2 46 25](https://github.com/user-attachments/assets/e53e3b95-d21e-41d3-aa45-8b2efd5478d1)

## 🔍 Test 
POST http://localhost:8080/api/v1/users/signup

{
    "username": "exampleUser123",
    "password": "앱 비밀번호 첨부",
    "email": "suunn001@gmail.com",
    "phoneNumber": "01011112222",
    "nickname": "역삼동거주민",
    "address": {
        "mainAddress": "서울시 강남구 역삼동",
        "detailAddress": "현대아파트 101동 202호",
        "zipcode": "04700"
    },
    "latitude": 37.517236,
    "longitude": 127.047324
}

<img width="419" alt="스크린샷 2025-03-05 오후 3 22 14" src="https://github.com/user-attachments/assets/151ffa11-1fbf-44f0-903c-96b9c0a21045" />
![스크린샷 2025-03-05 오후 2 49 47](https://github.com/user-attachments/assets/ab6d8d24-49dc-4421-a4fa-12b72658d426)

- 이메일 인증 받지 않은 사용자는 인증 불가능합니다
- 이메일 / 아이디 / 번호 / 닉네임이 같으면 가입 불가능합니다

## 🔗 Related Issues 
[[FEAT] 회원 가입 추가 #6 ](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/6)

## 📝 Note (주의 사항) 
추후 프론트에서 주소 인증한 후에 주소 값 저장 예정