### PR TITLE
[FEAT]마이페이지 유저정보 조회 및 대여일정 조회 로그인 적용 #17

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/postimage/repository/PostImageRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/postimage/repository/PostImageRepository.java
@@ -4,7 +4,10 @@ import com.snackoverflow.toolgether.domain.postimage.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
+    List<PostImage> findByPostId(Long postId);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/postimage/service/PostImageService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/postimage/service/PostImageService.java
@@ -1,9 +1,20 @@
 package com.snackoverflow.toolgether.domain.postimage.service;
 
+import com.snackoverflow.toolgether.domain.postimage.entity.PostImage;
+import com.snackoverflow.toolgether.domain.postimage.repository.PostImageRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PostImageService {
+    private final PostImageRepository postImageRepository;
+
+    public List<PostImage> getPostImagesByPostId(Long postId) {
+        return postImageRepository.findByPostId(postId);
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
@@ -1,8 +1,16 @@
 package com.snackoverflow.toolgether.domain.reservation.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    // renterId를 기준으로 예약 정보를 조회하는 메서드
+    List<Reservation> findByRenterId(Long renterId);
+
+    // ownerId를 기준으로 예약 정보를 조회하는 메서드
+    List<Reservation> findByOwnerId(Long ownerId);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
@@ -1,5 +1,9 @@
 package com.snackoverflow.toolgether.domain.reservation.service;
 
+import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
+import com.snackoverflow.toolgether.domain.reservation.entity.ReservationStatus;
+import com.snackoverflow.toolgether.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
 import java.net.URI;
 import java.time.LocalDateTime;
 
@@ -25,6 +29,10 @@ import com.snackoverflow.toolgether.global.exception.custom.ErrorResponse;
 import com.snackoverflow.toolgether.global.exception.custom.CustomException;
 
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -140,4 +148,16 @@ public class ReservationService {
 				.instance(URI.create(ServletUriComponentsBuilder.fromCurrentRequestUri().toUriString()))
 				.build()));
 	}
+
+    // 렌탈 예약 정보 DB에서 조회
+    @Transactional(readOnly = true)
+    public List<Reservation> getRentalReservations(Long userId) {
+        return reservationRepository.findByOwnerId(userId);
+    }
+
+    // 대여 예약 정보 DB에서 조회
+    @Transactional(readOnly = true)
+    public List<Reservation> getBorrowReservations(Long userId) {
+        return reservationRepository.findByRenterId(userId);
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/review/repository/ReviewRepository.java
@@ -4,6 +4,10 @@ import com.snackoverflow.toolgether.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    // userId와 reservationId를 사용하여 Review를 작성했는지 조회
+    Optional<Review> findByReviewer_IdAndReservation_Id(Long userId, Long reservationId);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/review/service/ReviewService.java
@@ -1,0 +1,20 @@
+package com.snackoverflow.toolgether.domain.review.service;
+
+import com.snackoverflow.toolgether.domain.review.entity.Review;
+import com.snackoverflow.toolgether.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+
+    public Optional<Review> findByUserIdAndReservationId(Long userId, Long reservationId) {
+        return reviewRepository.findByReviewer_IdAndReservation_Id(userId, reservationId);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/review/sevice/ReviewService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/review/sevice/ReviewService.java
@@ -1,9 +1,0 @@
-package com.snackoverflow.toolgether.domain.review.sevice;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-@Service
-@Transactional(readOnly = true)
-public class ReviewService {
-}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -1,15 +1,26 @@
 package com.snackoverflow.toolgether.domain.user.controller;
 
+import com.snackoverflow.toolgether.domain.postimage.entity.PostImage;
+import com.snackoverflow.toolgether.domain.postimage.service.PostImageService;
+import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
 import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
-import com.snackoverflow.toolgether.domain.review.sevice.ReviewService;
+import com.snackoverflow.toolgether.domain.review.service.ReviewService;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
+import com.snackoverflow.toolgether.domain.user.dto.MyReservationInfoResponse;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 import com.snackoverflow.toolgether.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/mypage")
@@ -19,9 +30,10 @@ public class MypageController {
     private final UserService userService;
     private final ReviewService reviewService;
     private final ReservationService reservationService;
+    private final PostImageService postImageService;
 
     @GetMapping("/me")
-    public RsData<MeInfoResponse> me() {
+    public RsData<MeInfoResponse> getMyInfo() {
         // TODO: 현재 로그인한 유저의 정보를 가져오는 로직을 추가해야 합니다.
         // 그 전까지는 baseInitData에서 생성한 첫번째 유저를 가져옵니다.
         if (false) {
@@ -34,6 +46,61 @@ public class MypageController {
                 "200-1",
                 "내 정보 조회 성공",
                 meInfoResponse
+        );
+    }
+
+    @GetMapping("/reservations")
+    public RsData<Map<String, List<MyReservationInfoResponse>>> getMyReservations() {
+        // TODO: 현재 로그인한 유저의 예약 정보를 가져오는 로직을 추가해야 합니다.
+        // 그 전까지는 baseInitData에서 생성한 첫번째 유저를 가져옵니다.
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        Long userId = ((com.snackoverflow.toolgether.domain.user.entity.User) authentication.getPrincipal()).getId(); // UserDetails 인터페이스 구현 필요
+
+        if (false) {
+            throw new ServiceException("401-1", "인증이 필요한 요청입니다");
+        } else if (false) {
+            throw new ServiceException("404-1", "해당 유저를 찾을 수 없습니다");
+        } else if (false) {
+            throw new ServiceException("403-1", "권한이 없는 요청입니다");
+        }
+        long userId = 2L;
+
+        List<Reservation> rentals = reservationService.getRentalReservations(userId);
+        List<Reservation> borrows = reservationService.getBorrowReservations(userId);
+
+        List<MyReservationInfoResponse> rentalResponses = rentals.stream()
+                .map(reservation -> {
+                    String imageUrl = null;
+                    List<PostImage> images = postImageService.getPostImagesByPostId(reservation.getPost().getId());  //PostImageService 호출
+                    if (images != null && !images.isEmpty()) {
+                        imageUrl = images.get(0).getPostImage();
+                    }
+                    boolean isReviewed = reviewService.findByUserIdAndReservationId(userId, reservation.getId()).isPresent();
+
+                    return MyReservationInfoResponse.from(reservation, imageUrl, isReviewed);
+                })
+                .collect(Collectors.toList());
+
+        List<MyReservationInfoResponse> borrowResponses = borrows.stream()
+                .map(reservation -> {
+                    String imageUrl = null;
+                    List<PostImage> images = postImageService.getPostImagesByPostId(reservation.getPost().getId());  //PostImageService 호출
+                    if (images != null && !images.isEmpty()) {
+                        imageUrl = images.get(0).getPostImage();
+                    }
+                    boolean isReviewed = reviewService.findByUserIdAndReservationId(userId, reservation.getId()).isPresent();
+                    return MyReservationInfoResponse.from(reservation, imageUrl, isReviewed);
+                })
+                .collect(Collectors.toList());
+
+        Map<String, List<MyReservationInfoResponse>> data = new HashMap<>();
+        data.put("rentals", rentalResponses);
+        data.put("borrows", borrowResponses);
+
+        return new RsData<>(
+                "200-1",
+                "마이페이지 예약 정보 조회 성공",
+                data
         );
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -1,0 +1,39 @@
+package com.snackoverflow.toolgether.domain.user.controller;
+
+import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
+import com.snackoverflow.toolgether.domain.review.sevice.ReviewService;
+import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
+import com.snackoverflow.toolgether.domain.user.service.UserService;
+import com.snackoverflow.toolgether.global.dto.RsData;
+import com.snackoverflow.toolgether.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class MypageController {
+
+    private final UserService userService;
+    private final ReviewService reviewService;
+    private final ReservationService reservationService;
+
+    @GetMapping("/me")
+    public RsData<MeInfoResponse> me() {
+        // TODO: 현재 로그인한 유저의 정보를 가져오는 로직을 추가해야 합니다.
+        // 그 전까지는 baseInitData에서 생성한 첫번째 유저를 가져옵니다.
+        if (false) {
+            throw new ServiceException("401-1", "인증이 필요한 요청입니다");
+        }
+        long id = 1L;
+        MeInfoResponse meInfoResponse = userService.getMeInfo(id);
+
+        return new RsData<>(
+                "200-1",
+                "내 정보 조회 성공",
+                meInfoResponse
+        );
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -11,8 +11,7 @@ import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 import com.snackoverflow.toolgether.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,6 +48,7 @@ public class MypageController {
         );
     }
 
+    @Transactional(readOnly = true)
     @GetMapping("/reservations")
     public RsData<Map<String, List<MyReservationInfoResponse>>> getMyReservations() {
         // TODO: 현재 로그인한 유저의 예약 정보를 가져오는 로직을 추가해야 합니다.

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -7,9 +7,12 @@ import com.snackoverflow.toolgether.domain.reservation.service.ReservationServic
 import com.snackoverflow.toolgether.domain.review.service.ReviewService;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.MyReservationInfoResponse;
+import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 import com.snackoverflow.toolgether.global.exception.ServiceException;
+import com.snackoverflow.toolgether.global.filter.CustomUserDetails;
+import com.snackoverflow.toolgether.global.filter.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,14 +35,13 @@ public class MypageController {
     private final PostImageService postImageService;
 
     @GetMapping("/me")
-    public RsData<MeInfoResponse> getMyInfo() {
-        // TODO: 현재 로그인한 유저의 정보를 가져오는 로직을 추가해야 합니다.
-        // 그 전까지는 baseInitData에서 생성한 첫번째 유저를 가져옵니다.
-        if (false) {
-            throw new ServiceException("401-1", "인증이 필요한 요청입니다");
-        }
-        long id = 1L;
-        MeInfoResponse meInfoResponse = userService.getMeInfo(id);
+    public RsData<MeInfoResponse> getMyInfo(
+            @Login CustomUserDetails customUserDetails
+    ) {
+        String username = customUserDetails.getUsername();
+        User user = userService.findByUsername(username);
+        Long userId = user.getId();
+        MeInfoResponse meInfoResponse = userService.getMeInfo(userId);
 
         return new RsData<>(
                 "200-1",
@@ -50,20 +52,12 @@ public class MypageController {
 
     @Transactional(readOnly = true)
     @GetMapping("/reservations")
-    public RsData<Map<String, List<MyReservationInfoResponse>>> getMyReservations() {
-        // TODO: 현재 로그인한 유저의 예약 정보를 가져오는 로직을 추가해야 합니다.
-        // 그 전까지는 baseInitData에서 생성한 첫번째 유저를 가져옵니다.
-//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-//        Long userId = ((com.snackoverflow.toolgether.domain.user.entity.User) authentication.getPrincipal()).getId(); // UserDetails 인터페이스 구현 필요
-
-        if (false) {
-            throw new ServiceException("401-1", "인증이 필요한 요청입니다");
-        } else if (false) {
-            throw new ServiceException("404-1", "해당 유저를 찾을 수 없습니다");
-        } else if (false) {
-            throw new ServiceException("403-1", "권한이 없는 요청입니다");
-        }
-        long userId = 2L;
+    public RsData<Map<String, List<MyReservationInfoResponse>>> getMyReservations(
+            @Login CustomUserDetails customUserDetails
+    ) {
+        String username = customUserDetails.getUsername();
+        User user = userService.findByUsername(username);
+        Long userId = user.getId();
 
         List<Reservation> rentals = reservationService.getRentalReservations(userId);
         List<Reservation> borrows = reservationService.getBorrowReservations(userId);

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/AddressInfo.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/AddressInfo.java
@@ -1,0 +1,17 @@
+package com.snackoverflow.toolgether.domain.user.dto;
+
+import com.snackoverflow.toolgether.domain.user.entity.Address;
+
+public record AddressInfo(
+        String mainAddress,
+        String detailAddress,
+        String zipcode
+) {
+    public static AddressInfo from(Address address) {
+        return new AddressInfo(
+                address.getMainAddress(),
+                address.getDetailAddress(),
+                address.getZipcode()
+        );
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MeInfoResponse.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MeInfoResponse.java
@@ -11,7 +11,7 @@ public record MeInfoResponse(
         @NonNull String nickname,
         String username,
         String profileImage,
-        @NonNull String email,
+        String email,
         @NonNull String phoneNumber,
         @NonNull AddressInfo address,
         @NonNull LocalDateTime createdAt,

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MeInfoResponse.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MeInfoResponse.java
@@ -1,0 +1,35 @@
+package com.snackoverflow.toolgether.domain.user.dto;
+
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+public record MeInfoResponse(
+        @NonNull Long id,
+        @NonNull String nickname,
+        String username,
+        String profileImage,
+        @NonNull String email,
+        @NonNull String phoneNumber,
+        @NonNull AddressInfo address,
+        @NonNull LocalDateTime createdAt,
+        @NonNull Integer score,
+        @NonNull Integer credit
+) {
+    public static MeInfoResponse from(User user) {
+        return new MeInfoResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getUsername(),
+                user.getProfileImage(),
+                user.getEmail(),
+                user.getPhoneNumber(),
+                AddressInfo.from(user.getAddress()),
+                user.getCreatedAt(),
+                user.getScore(),
+                user.getCredit()
+        );
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MyReservationInfoResponse.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MyReservationInfoResponse.java
@@ -1,0 +1,31 @@
+package com.snackoverflow.toolgether.domain.user.dto;
+
+import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
+import lombok.NonNull;
+
+import java.time.LocalDateTime;
+
+public record MyReservationInfoResponse(
+        @NonNull Long id,
+        @NonNull String title,
+        String image,
+        @NonNull Double amount,
+        @NonNull LocalDateTime startTime,
+        @NonNull LocalDateTime endTime,
+        @NonNull String status,
+        @NonNull Boolean isReviewed
+) {
+    public static MyReservationInfoResponse from(Reservation reservation, String imageUrl, boolean isReviewed) {
+
+        return new MyReservationInfoResponse(
+                reservation.getId(),
+                reservation.getPost().getTitle(),
+                imageUrl,
+                reservation.getAmount(),
+                reservation.getStartTime(),
+                reservation.getEndTime(),
+                reservation.getStatus().toString(),
+                isReviewed
+        );
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -1,10 +1,13 @@
 package com.snackoverflow.toolgether.domain.user.service;
 
+import org.springframework.transaction.annotation.Transactional;
+import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.user.dto.request.SignupRequest;
 import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
 import com.snackoverflow.toolgether.global.exception.custom.duplicate.DuplicateFieldException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.VerificationException;
+import com.snackoverflow.toolgether.global.exception.ServiceException;
 import com.snackoverflow.toolgether.global.exception.custom.user.UserNotFoundException;
 import com.snackoverflow.toolgether.global.util.JwtUtil;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,6 +69,7 @@ public class UserService {
         userRepository.save(user);
     }
 
+
     // 기본 사용자 로그인
     public LoginResult loginUser(String username, String password) {
         User user = userRepository.findByUsername(username).orElseThrow(() ->
@@ -104,5 +108,13 @@ public class UserService {
                 .orElseThrow(() -> new RuntimeException("User not found"));
         user.updateCredit(credit); // updateCredit() 메서드 호출
         return user;
+    }
+
+    @Transactional(readOnly = true)
+    public MeInfoResponse getMeInfo(long id) {
+        User user = userRepository.findById(id).orElseThrow(
+                () -> new ServiceException("404-1", "해당 유저를 찾을 수 없습니다")
+        );
+        return MeInfoResponse.from(user);
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -74,10 +74,10 @@ public class UserService {
     public LoginResult loginUser(String username, String password) {
         User user = userRepository.findByUsername(username).orElseThrow(() ->
                 new UserNotFoundException("존재하지 않는 사용자: " + username));
-//TODO 커밋 전에 비밀번호 주석 풀기. yml에서 jwt 설정도 제외!
-//        if (!passwordEncoder.matches(password, user.getPassword())) {
-//            throw new UserNotFoundException("비밀번호가 올바르지 않습니다.");
-//        }
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new UserNotFoundException("비밀번호가 올바르지 않습니다.");
+        }
 
         // username 기반으로 토큰 생성
         Map<String, Object> claims = new HashMap<>();

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -74,10 +74,10 @@ public class UserService {
     public LoginResult loginUser(String username, String password) {
         User user = userRepository.findByUsername(username).orElseThrow(() ->
                 new UserNotFoundException("존재하지 않는 사용자: " + username));
-
-        if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new UserNotFoundException("비밀번호가 올바르지 않습니다.");
-        }
+//TODO 커밋 전에 비밀번호 주석 풀기. yml에서 jwt 설정도 제외!
+//        if (!passwordEncoder.matches(password, user.getPassword())) {
+//            throw new UserNotFoundException("비밀번호가 올바르지 않습니다.");
+//        }
 
         // username 기반으로 토큰 생성
         Map<String, Object> claims = new HashMap<>();
@@ -116,5 +116,11 @@ public class UserService {
                 () -> new ServiceException("404-1", "해당 유저를 찾을 수 없습니다")
         );
         return MeInfoResponse.from(user);
+    }
+
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username).orElseThrow(
+                () -> new ServiceException("404-1", "해당 유저를 찾을 수 없습니다")
+        );
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/ServiceException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/ServiceException.java
@@ -1,0 +1,25 @@
+package com.snackoverflow.toolgether.global.exception;
+
+
+import com.snackoverflow.toolgether.global.dto.RsData;
+
+public class ServiceException extends RuntimeException {
+    private final RsData<?> rsData;
+
+    public ServiceException(String code, String message) {
+        super(message);
+        rsData = new RsData<>(code, message);
+    }
+
+    public String getCode() {
+        return rsData.getCode();
+    }
+
+    public String getMsg() {
+        return rsData.getMsg();
+    }
+
+    public int getStatusCode() {
+        return rsData.getStatusCode();
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
@@ -1,5 +1,9 @@
 package com.snackoverflow.toolgether.global.init;
 
+import com.snackoverflow.toolgether.domain.user.entity.Address;
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
@@ -17,11 +21,11 @@ import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
 
 @Configuration
 @RequiredArgsConstructor
 public class BaseInitData {
-
 	private final PostRepository postRepository;
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
@@ -36,6 +40,13 @@ public class BaseInitData {
 			self.reservationInit();
 		};
 	}
+
+    @Bean
+    public ApplicationRunner applicationRunner2() {
+        return args -> {
+            self.userInit();
+        };
+    }
 
 	@Transactional
 	public void reservationInit() {
@@ -85,4 +96,99 @@ public class BaseInitData {
 			.build();
 		postRepository.save(post2);
 	}
+
+    @Transactional
+    public void userInit() {
+        System.out.println("UserInitData 실행");
+        if (userRepository.count() > 0) {
+            return;
+        }
+        try {
+            // Address 객체 생성
+            Address address1 = Address.builder()
+                    .mainAddress("서울시 강남구")
+                    .detailAddress("역삼동 123-45")
+                    .zipcode("12345")
+                    .build();
+
+            // 첫 번째 사용자 생성
+            User user1 = User.builder()
+                    .username("testId1")
+                    .password("password")
+                    .nickname("닉네임1")
+                    .email("test1@gmail.com")
+                    .phoneNumber("000-0000-0001")
+                    .address(address1)
+                    .latitude(37.123)
+                    .longitude(127.123)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            userRepository.saveAndFlush(user1);
+
+            // 두 번째 사용자 생성
+            Address address2 = Address.builder()
+                    .mainAddress("서울시 서초구")
+                    .detailAddress("양재동 678-90")
+                    .zipcode("67890")
+                    .build();
+            User user2 = User.builder()
+                    .username("testId2")
+                    .password("password")
+                    .nickname("닉네임2")
+                    .email("test2@gmail.com")
+                    .phoneNumber("000-0000-0002")
+                    .address(address2)
+                    .latitude(37.456)
+                    .longitude(127.456)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            userRepository.saveAndFlush(user2);
+
+            // 세 번째 사용자 생성
+            Address address3 = Address.builder()
+                    .mainAddress("서울시 종로구")
+                    .detailAddress("청진동 101-11")
+                    .zipcode("10111")
+                    .build();
+            User user3 = User.builder()
+                    .username("testId3")
+                    .password("password")
+                    .nickname("닉네임3")
+                    .email("test3@gmail.com")
+                    .phoneNumber("000-0000-0003")
+                    .address(address3)
+                    .latitude(37.789)
+                    .longitude(127.789)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            userRepository.saveAndFlush(user3);
+
+            // Google 소셜 로그인 사용자 생성
+            Address googleAddress = Address.builder()
+                    .mainAddress("미국 캘리포니아") // 임의의 주소
+                    .detailAddress("구글 본사") // 임의의 주소
+                    .zipcode("94043") // 임의의 우편번호
+                    .build();
+            User googleUser = User.builder()
+                    .username(null) // 소셜 로그인은 username이 없을 수 있습니다.
+                    .password(null) // 소셜 로그인은 password가 없습니다.
+                    .nickname("구글유저")
+                    .email("googleuser@gmail.com")
+                    .phoneNumber("000-0000-0004") // 소셜 로그인은 전화번호가 없을 수 있습니다.
+                    .address(googleAddress) // 소셜 로그인은 주소가 없을 수 있습니다.
+                    .latitude(37.123) // 적절한 위도/경도 값 설정
+                    .longitude(127.123)
+                    .createdAt(LocalDateTime.now())
+                    .provider("google") // provider 를 google 로 설정
+                    .providerId("google123456789") // 실제 providerId를 설정해야 합니다.
+                    .build();
+            userRepository.saveAndFlush(googleUser);
+
+            System.out.println("UserRepositoryTest 실행 완료");
+
+        } catch (Exception e) {
+            System.err.println("UserRepositoryTest 실행 중 오류 발생: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
@@ -62,23 +62,24 @@ public class BaseInitData {
 	public void reservationInit() {
 
 //        UserInitData 전부 삭제 후 재생성 코드
-//        reviewRepository.deleteAll();
-//        reservationRepository.deleteAll();
-//        postRepository.deleteAll();
-//        userRepository.deleteAll();
+        reviewRepository.deleteAll();
+        reservationRepository.deleteAll();
+        postRepository.deleteAll();
+        userRepository.deleteAll();
 //
 //        // AUTO_INCREMENT 초기화
-//        entityManager.createNativeQuery("ALTER TABLE review AUTO_INCREMENT = 1").executeUpdate();
-//        entityManager.createNativeQuery("ALTER TABLE reservation AUTO_INCREMENT = 1").executeUpdate();
-//        entityManager.createNativeQuery("ALTER TABLE post AUTO_INCREMENT = 1").executeUpdate();
-//        entityManager.createNativeQuery("ALTER TABLE users AUTO_INCREMENT = 1").executeUpdate();
+        entityManager.createNativeQuery("ALTER TABLE review AUTO_INCREMENT = 1").executeUpdate();
+        entityManager.createNativeQuery("ALTER TABLE reservation AUTO_INCREMENT = 1").executeUpdate();
+        entityManager.createNativeQuery("ALTER TABLE post AUTO_INCREMENT = 1").executeUpdate();
+        entityManager.createNativeQuery("ALTER TABLE users AUTO_INCREMENT = 1").executeUpdate();
 
         if(userRepository.count() > 0) {
 			return;
 		}
 		User user1 = User.builder()
 			.address(new Address("서울", "강남구", "12345")) // Address 객체 생성 및 설정
-			.nickname("사람")
+			.username("human123")
+			.nickname("사람이")
 			.password("1234")
 			.score(30)
 			.phoneNumber("01012345678")
@@ -99,6 +100,7 @@ public class BaseInitData {
 
 		User user2 = User.builder()
 			.address(new Address("부산", "해운대구", "67890"))
+			.username("seaman222")
 			.nickname("바다사람")
 			.password("5678")
 			.score(50)
@@ -122,7 +124,7 @@ public class BaseInitData {
         User googleUser = User.builder()
                 .username(null)
                 .password(null)
-                .nickname("구글유저")
+                .nickname("googleUser")
                 .email("googleuser@gmail.com")
                 .phoneNumber("000-0000-0004")
                 .address(new Address("서울시 종로구", "청진동 101-11", "10111"))

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
@@ -62,16 +62,16 @@ public class BaseInitData {
 	public void reservationInit() {
 
 //        UserInitData 전부 삭제 후 재생성 코드
-        reviewRepository.deleteAll();
-        reservationRepository.deleteAll();
-        postRepository.deleteAll();
-        userRepository.deleteAll();
+//        reviewRepository.deleteAll();
+//        reservationRepository.deleteAll();
+//        postRepository.deleteAll();
+//        userRepository.deleteAll();
 //
 //        // AUTO_INCREMENT 초기화
-        entityManager.createNativeQuery("ALTER TABLE review AUTO_INCREMENT = 1").executeUpdate();
-        entityManager.createNativeQuery("ALTER TABLE reservation AUTO_INCREMENT = 1").executeUpdate();
-        entityManager.createNativeQuery("ALTER TABLE post AUTO_INCREMENT = 1").executeUpdate();
-        entityManager.createNativeQuery("ALTER TABLE users AUTO_INCREMENT = 1").executeUpdate();
+//        entityManager.createNativeQuery("ALTER TABLE review AUTO_INCREMENT = 1").executeUpdate();
+//        entityManager.createNativeQuery("ALTER TABLE reservation AUTO_INCREMENT = 1").executeUpdate();
+//        entityManager.createNativeQuery("ALTER TABLE post AUTO_INCREMENT = 1").executeUpdate();
+//        entityManager.createNativeQuery("ALTER TABLE users AUTO_INCREMENT = 1").executeUpdate();
 
         if(userRepository.count() > 0) {
 			return;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,8 +37,8 @@ spring:
     open-in-view: false
 
   mail:
-    username: [본인 이메일 작성]
-    password: [앱 비밀번호 변경]
+    username: writeyourmail0123@gmail.com
+    password: writeAppPassword
     host: smtp.gmail.com
     port: 587
     properties:

--- a/backend/src/test/java/com/snackoverflow/toolgether/MypageControllerTest.java
+++ b/backend/src/test/java/com/snackoverflow/toolgether/MypageControllerTest.java
@@ -1,0 +1,169 @@
+package com.snackoverflow.toolgether;
+
+import com.snackoverflow.toolgether.domain.post.entity.Post;
+import com.snackoverflow.toolgether.domain.postimage.service.PostImageService;
+import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
+import com.snackoverflow.toolgether.domain.reservation.entity.ReservationStatus;
+import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
+import com.snackoverflow.toolgether.domain.review.service.ReviewService;
+import com.snackoverflow.toolgether.domain.user.controller.MypageController;
+import com.snackoverflow.toolgether.domain.user.dto.AddressInfo;
+import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
+import com.snackoverflow.toolgether.domain.user.dto.MyReservationInfoResponse;
+import com.snackoverflow.toolgether.domain.user.entity.Address;
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import com.snackoverflow.toolgether.domain.user.service.UserService;
+import com.snackoverflow.toolgether.global.dto.RsData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+public class MypageControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Mock
+	private UserService userService;
+
+	@Mock
+	private ReviewService reviewService;
+
+	@Mock
+	private ReservationService reservationService;
+
+	@Mock
+	private PostImageService postImageService;
+
+	@InjectMocks
+	private MypageController mypageController;
+
+	@BeforeEach
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+		mockMvc = MockMvcBuilders.standaloneSetup(mypageController).build();
+	}
+
+	@Test
+	@DisplayName("내 정보 조회 테스트")
+	public void testGetMyInfo() throws Exception {
+		Address address = Address.builder()
+				.mainAddress("서울시 강남구")
+				.detailAddress("역삼동 123-45")
+				.zipcode("12345")
+				.build();
+
+		User user = User.builder()
+				.id(1L)
+				.username("testId1")
+				.nickname("닉네임1")
+				.email("test1@gmail.com")
+				.phoneNumber("000-0000-0001")
+				.address(address)
+				.createdAt(LocalDateTime.now())
+				.score(30)
+				.credit(0)
+				.build();
+
+		MeInfoResponse meInfoResponse = MeInfoResponse.from(user);
+		when(userService.getMeInfo(1L)).thenReturn(meInfoResponse);
+
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/mypage/me"))
+				.andDo(print());
+
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("200-1"))
+				.andExpect(jsonPath("$.msg").value("내 정보 조회 성공"))
+				.andExpect(jsonPath("$.data.nickname").value("닉네임1"))
+				.andExpect(jsonPath("$.data.email").value("test1@gmail.com"));
+
+		verify(userService, times(1)).getMeInfo(1L);
+	}
+
+	@Test
+	@DisplayName("예약 정보 조회 테스트")
+	public void testGetMyReservations() throws Exception {
+		User user1 = User.builder()
+				.id(1L)
+				.username("testId1")
+				.nickname("닉네임1")
+				.email("test1@gmail.com")
+				.phoneNumber("000-0000-0001")
+				.address(Address.builder()
+						.mainAddress("서울시 강남구")
+						.detailAddress("역삼동 123-45")
+						.zipcode("12345")
+						.build())
+				.createdAt(LocalDateTime.now())
+				.score(30)
+				.credit(0)
+				.build();
+		Post post1 = Post.builder()
+				.id(10L)
+				.title("Sample Post Title")
+				.build();
+		Reservation reservation1 = Reservation.builder()
+				.id(1L)
+				.post(post1)
+				.renter(user1)
+				.owner(user1)
+				.createAt(LocalDateTime.now())
+				.startTime(LocalDateTime.now())
+				.endTime(LocalDateTime.now().plusHours(1))
+				.status(ReservationStatus.APPROVED)
+				.amount(10000.0)
+				.build();
+
+		MyReservationInfoResponse myReservationInfoResponse = MyReservationInfoResponse.from(reservation1, "imageUrl", false);
+
+		List<Reservation> rentals = new ArrayList<>();
+		rentals.add(reservation1);
+
+		List<MyReservationInfoResponse> rentalResponses = new ArrayList<>();
+		rentalResponses.add(myReservationInfoResponse);
+
+		Map<String, List<MyReservationInfoResponse>> data = new HashMap<>();
+		data.put("rentals", rentalResponses);
+		data.put("borrows", new ArrayList<>());
+
+		RsData<Map<String, List<MyReservationInfoResponse>>> rsData = new RsData<>("200-1", "마이페이지 예약 정보 조회 성공", data);
+
+
+		when(reservationService.getRentalReservations(2L)).thenReturn(rentals);
+		when(reservationService.getBorrowReservations(2L)).thenReturn(new ArrayList<>());
+		when(postImageService.getPostImagesByPostId(any())).thenReturn(new ArrayList<>());
+		when(reviewService.findByUserIdAndReservationId(anyLong(), anyLong())).thenReturn(Optional.empty());
+
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/mypage/reservations"))
+				.andDo(print());
+
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("200-1"))
+				.andExpect(jsonPath("$.msg").value("마이페이지 예약 정보 조회 성공"))
+				.andExpect(jsonPath("$.data.rentals[0].title").value("Sample Post Title"))
+				.andExpect(jsonPath("$.data.borrows").isEmpty());
+
+		verify(reservationService, times(1)).getRentalReservations(2L);
+		verify(reservationService, times(1)).getBorrowReservations(2L);
+	}
+}


### PR DESCRIPTION
- 마이페이지 유저정보 조회
- 대여일정 조회 
- 로그인 적용

+ 📸 Screenshot or Test Result

## 🔍 Test 
![image](https://github.com/user-attachments/assets/f59a049b-ccaa-4c27-aee2-b8f47f3f1434)

![image](https://github.com/user-attachments/assets/6ab2e647-7bf0-49a6-bb31-79aa593205be)

![image](https://github.com/user-attachments/assets/f826249a-20f4-459b-9c39-496378644c4f)


## 🔗 Related Issues 
[[FEAT] 백엔드 마이페이지 화면 로직 구현 #17](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/17)

## 📝 Note (주의 사항) 
*포스트맨으로 테스트 시 로그인 후 요청 필수
*BaseInitialData에 기존 데이터 삭제 후 Auto_increment도 초기화하는 코드 주석처리되어 있습니다. 만약 오류나면 주석을 한 번 실행하고 다시 진행해주세요.
*application.yml에 jwt 설정이 있어야 작동합니다.