### PR TITLE
✨ feat: 유저 예약 일정에 맞춘 캘린더 잠금 로직 구현 (FEAT #28)

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
@@ -86,10 +86,10 @@ public class ReservationController {
 
 	@GetMapping("/reservatedDates/{id}")
 	public RsData<Set<LocalDate>> getReservedDates(@PathVariable Long id) {
-		Set<LocalDate> reservationDates = reservationService.getDateListByUserId(id);
+		Set<LocalDate> reservationDates = reservationService.getDateListByPostId(id);
 		return new RsData<>(
 			"200-1",
-			"%d번 유저의 예약 일정 조회 성공".formatted(id),
+			"%d번 게시글의 예약 일정 조회 성공".formatted(id),
 			reservationDates
 		);
 	}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
@@ -1,5 +1,8 @@
 package com.snackoverflow.toolgether.domain.reservation.controller;
 
+import java.time.LocalDate;
+import java.util.Set;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,7 +36,7 @@ public class ReservationController {
 	@PatchMapping("/{id}/approve")
 	public RsData<Void> approveReservation(@PathVariable Long id) {
 		reservationService.approveReservation(id);
-		return new RsData<>("200-1",
+		return new RsData<>("201-1",
 			"%d번 예약 승인 성공".formatted(id));
 	}
 
@@ -78,6 +81,16 @@ public class ReservationController {
 		return new RsData<>("200-1",
 			"%d번 예약 조회 성공".formatted(id),
 			response
+		);
+	}
+
+	@GetMapping("/reservatedDates/{id}")
+	public RsData<Set<LocalDate>> getReservedDates(@PathVariable Long id) {
+		Set<LocalDate> reservationDates = reservationService.getDateListByUserId(id);
+		return new RsData<>(
+			"200-1",
+			"%d번 유저의 예약 일정 조회 성공".formatted(id),
+			reservationDates
 		);
 	}
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
@@ -13,4 +13,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     // ownerId를 기준으로 예약 정보를 조회하는 메서드
     List<Reservation> findByOwnerId(Long ownerId);
+
+    List<Reservation> findByPostId(Long postId);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
@@ -24,22 +24,13 @@ import com.snackoverflow.toolgether.domain.reservation.entity.FailDue;
 import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.reservation.dto.ReservationRequest;
 import com.snackoverflow.toolgether.domain.reservation.dto.ReservationResponse;
-import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
-import com.snackoverflow.toolgether.domain.reservation.entity.ReservationStatus;
-import com.snackoverflow.toolgether.domain.reservation.repository.ReservationRepository;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.exception.ServiceException;
 import com.snackoverflow.toolgether.global.exception.custom.ErrorResponse;
 import com.snackoverflow.toolgether.global.exception.custom.CustomException;
 
-import lombok.RequiredArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service

--- a/frontend/app/reservation/ClientPage.tsx
+++ b/frontend/app/reservation/ClientPage.tsx
@@ -67,17 +67,17 @@ export default function ClientPage({
 
   useEffect(() => {
     const loadReservedDates = async () => {
-      const dates = await fetchReservedDates(me.id);
+      const dates = await fetchReservedDates(post.id);
       setReservedDates(dates);
     };
     loadReservedDates();
   }, [me.id]);
 
   // 예약된 날짜 가져오기
-  const fetchReservedDates = async (userId: number) => {
+  const fetchReservedDates = async (postId: number) => {
     try {
       const response = await fetch(
-        `http://localhost:8080/api/v1/reservations/reservatedDates/${userId}`
+        `http://localhost:8080/api/v1/reservations/reservatedDates/${postId}`
       );
       if (response.ok) {
         const data = await response.json();


### PR DESCRIPTION
## ✅ Check List
- [x] 잠금을 위한 일정 리스트 출력 로직 구현
- [x] 프론트엔드 API 연결 후 캘린더에 잠금 활성화
- [x] 요청/거절/완료/실패 상태의 예약 필터링

## 🔍 Test 
![image](https://github.com/user-attachments/assets/3492dc2f-dfb2-4e5e-ae96-36e1bdd1605a)

GET http://localhost:8080/api/v1/reservations/reservatedDates/1 

![image](https://github.com/user-attachments/assets/e6655ab0-b5fa-4e04-b84a-7547f1f2ef8f)


  1. 실제 작동 화면
  2. 게시글 승인 or 진행 중인 상태 예약의 일정 추출

## 🔗 Related Issues 
[[FEAT] 유저 예약 일정에 맞춘 캘린더 잠금 로직 구현](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/28)
