### PR TITLE
✨ feat: 백엔드 마이페이지 개인정보 수정 및 삭제 로직 구현

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -7,17 +7,16 @@ import com.snackoverflow.toolgether.domain.reservation.service.ReservationServic
 import com.snackoverflow.toolgether.domain.review.service.ReviewService;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.MyReservationInfoResponse;
+import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
 import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
-import com.snackoverflow.toolgether.global.exception.ServiceException;
 import com.snackoverflow.toolgether.global.filter.CustomUserDetails;
 import com.snackoverflow.toolgether.global.filter.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +33,7 @@ public class MypageController {
     private final ReservationService reservationService;
     private final PostImageService postImageService;
 
+    //내 정보 조회
     @GetMapping("/me")
     public RsData<MeInfoResponse> getMyInfo(
             @Login CustomUserDetails customUserDetails
@@ -50,6 +50,7 @@ public class MypageController {
         );
     }
 
+    //예약 조회
     @Transactional(readOnly = true)
     @GetMapping("/reservations")
     public RsData<Map<String, List<MyReservationInfoResponse>>> getMyReservations(
@@ -97,4 +98,24 @@ public class MypageController {
                 data
         );
     }
+
+    //이미지 제외한 수정 가능한 내 정보 수정
+    @PatchMapping("/me")
+    public RsData<Void> PostMyInfo(
+            @Login CustomUserDetails customUserDetails,
+            @RequestBody @Validated PatchMyInfoRequest request
+    ) {
+        String username = customUserDetails.getUsername();
+        User user = userService.findByUsername(username);
+        userService.checkMyInfoDuplicates(request);
+        userService.updateMyInfo(user, request);
+
+        return new RsData<>(
+                "200-1",
+                "내 정보 수정 성공"
+        );
+    }
+
+    //회원 탈퇴
+
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -8,11 +8,13 @@ import com.snackoverflow.toolgether.domain.review.service.ReviewService;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.MyReservationInfoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
+import com.snackoverflow.toolgether.domain.user.dto.request.ProfileRequest;
 import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 import com.snackoverflow.toolgether.global.filter.CustomUserDetails;
 import com.snackoverflow.toolgether.global.filter.Login;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -96,6 +98,35 @@ public class MypageController {
                 "200-1",
                 "마이페이지 예약 정보 조회 성공",
                 data
+        );
+    }
+
+    //프로필 이미지 업로드
+    @PostMapping("/profile")
+    public RsData<Void> postProfileimage(
+            @Login CustomUserDetails customUserDetails,
+            @RequestBody @NotNull @Validated ProfileRequest profileRequest
+    ) {
+        String username = customUserDetails.getUsername();
+        User user = userService.findByUsername(username);
+        userService.postProfileImage(user, profileRequest.getUuid());
+        return new RsData<>(
+                "200-1",
+                "프로필 이미지 업로드가 완료되었습니다"
+        );
+    }
+
+    //프로필 이미지 삭제
+    @DeleteMapping("/profile")
+    public RsData<Void> deleteProfileImage(
+            @Login CustomUserDetails customUserDetails
+    ) {
+        String username = customUserDetails.getUsername();
+        User user = userService.findByUsername(username);
+        userService.deleteProfileImage(user);
+        return new RsData<>(
+                "200-1",
+                "프로필 이미지 삭제가 완료되었습니다"
         );
     }
 

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -117,5 +117,16 @@ public class MypageController {
     }
 
     //회원 탈퇴
-
+    @DeleteMapping("/me")
+    public RsData<Void> DeleteMe(
+            @Login CustomUserDetails customUserDetails
+    ) {
+        String username = customUserDetails.getUsername();
+        User user = userService.findByUsername(username);
+        userService.deleteUser(user);
+        return new RsData<>(
+                "200-1",
+                "회원 탈퇴가 완료되었습니다."
+        );
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/PatchMyInfoRequest.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/PatchMyInfoRequest.java
@@ -1,0 +1,29 @@
+package com.snackoverflow.toolgether.domain.user.dto.request;
+
+import com.snackoverflow.toolgether.domain.user.entity.Address;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+
+@Data
+public class PatchMyInfoRequest {
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "전화번호를 입력해주세요 [하이픈 제외]")
+    private String phoneNumber;
+
+    @NotBlank(message = "닉네임을 입력해주세요")
+    @Pattern(regexp = "^[가-힣]{4,10}$", message = "닉네임은 한글 4~10자로 입력해주세요")
+    private String nickname;
+
+    @Valid
+    private Address address;
+
+    @NotNull
+    private Double latitude; // 위도
+
+    @NotNull
+    private Double longitude; // 경도
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/ProfileRequest.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/ProfileRequest.java
@@ -1,0 +1,12 @@
+package com.snackoverflow.toolgether.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class ProfileRequest {
+    @NotBlank
+    private String uuid;
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
@@ -97,13 +97,13 @@ public class User {
         this.additionalInfoRequired = additionalInfoRequired;
     }
 
-//    public void updateAddress(String zipcode, String mainAddress, String detailAddress) {
-//        this.address = Address.builder()
-//                .zipcode(zipcode)
-//                .mainAddress(mainAddress)
-//                .detailAddress(detailAddress)
-//                .build();
-//    }
+    public void updateAddress(String zipcode, String mainAddress, String detailAddress) {
+        this.address = Address.builder()
+                .zipcode(zipcode)
+                .mainAddress(mainAddress)
+                .detailAddress(detailAddress)
+                .build();
+    }
 
     public void updateEmail(String email) {
         this.email = email;
@@ -112,11 +112,6 @@ public class User {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
-
-    public void updateAddress(Address address) {
-        this.address = address;
-    }
-
 
     public void updateProfileImage(String uuid) {
         this.profileImage = uuid;

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.snackoverflow.toolgether.domain.user.entity;
 
+import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -94,5 +95,17 @@ public class User {
                 .mainAddress(mainAddress)
                 .detailAddress(detailAddress)
                 .build();
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateAddress(Address address) {
+        this.address = address;
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
@@ -118,6 +118,14 @@ public class User {
     }
 
 
+    public void updateProfileImage(String uuid) {
+        this.profileImage = uuid;
+    }
+
+    public void deleteProfileImage() {
+        this.profileImage = null;
+    }
+
     //탈퇴시 호출, 삭제 시간을 기록하고 익명화 진행
     @PreUpdate
     public void preUpdate() {

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
@@ -1,15 +1,20 @@
 package com.snackoverflow.toolgether.domain.user.entity;
 
 import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
+import com.snackoverflow.toolgether.global.util.Util;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
+import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -68,6 +73,9 @@ public class User {
     @Builder.Default
     private int credit = 0; // 보증금 환불 필드
 
+    @Column(nullable = true)
+    private LocalDateTime deletedAt; // 탈퇴 일자, 탈퇴하면 null이 아님
+
     public void updateCredit(int credit) {
         this.credit += credit;
     }
@@ -86,16 +94,16 @@ public class User {
     }
 
     public void updateAdditionalInfoRequired(boolean additionalInfoRequired) {
-            this.additionalInfoRequired = additionalInfoRequired;
+        this.additionalInfoRequired = additionalInfoRequired;
     }
 
-    public void updateAddress(String zipcode, String mainAddress, String detailAddress) {
-        this.address = Address.builder()
-                .zipcode(zipcode)
-                .mainAddress(mainAddress)
-                .detailAddress(detailAddress)
-                .build();
-    }
+//    public void updateAddress(String zipcode, String mainAddress, String detailAddress) {
+//        this.address = Address.builder()
+//                .zipcode(zipcode)
+//                .mainAddress(mainAddress)
+//                .detailAddress(detailAddress)
+//                .build();
+//    }
 
     public void updateEmail(String email) {
         this.email = email;
@@ -107,5 +115,35 @@ public class User {
 
     public void updateAddress(Address address) {
         this.address = address;
+    }
+
+
+    //탈퇴시 호출, 삭제 시간을 기록하고 익명화 진행
+    @PreUpdate
+    public void preUpdate() {
+        if (this.deletedAt != null) {
+            anonymize();
+        }
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    // 개인 정보 익명화
+    public void anonymize() {
+        this.username = "deletedUser-" + Util.generateUUIDMasking();
+        this.password = Util.generateUUIDMasking();
+        this.email = Util.generateUUIDMasking() + "@deleted.com";
+        this.phoneNumber = Util.generateUUIDMasking();
+        this.nickname = "삭제된유저-" + Util.generateUUIDMasking();
+        this.address = new Address(
+                "삭제된 주소",
+                "삭제된 상세 주소",
+                "00000"
+        );
+        this.latitude = 0.0;
+        this.longitude = 0.0;
+        this.profileImage = null;
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.snackoverflow.toolgether.domain.user.repository;
 
 import com.snackoverflow.toolgether.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -17,4 +18,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    boolean existsByPhoneNumber(String phoneNumber);
+
+    Optional<User> findById(long id);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.snackoverflow.toolgether.domain.user.service;
 
+import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
 import org.springframework.transaction.annotation.Transactional;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.entity.User;
@@ -38,6 +39,18 @@ public class UserService {
         }
         if (userRepository.existsByNickname(request.getNickname())) {
             throw new DuplicateFieldException("사용자 닉네임 중복 오류 발생");
+        }
+    }
+
+    public void checkMyInfoDuplicates(PatchMyInfoRequest request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateFieldException("사용자 EMAIL 중복 오류 발생");
+        }
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new DuplicateFieldException("사용자 닉네임 중복 오류 발생");
+        }
+        if (userRepository.existsByPhoneNumber(request.getPhoneNumber())) {
+            throw new DuplicateFieldException("사용자 전화번호 중복 오류 발생");
         }
     }
 
@@ -119,5 +132,15 @@ public class UserService {
         return userRepository.findByUsername(username).orElseThrow(
                 () -> new ServiceException("404-1", "해당 유저를 찾을 수 없습니다")
         );
+    }
+
+    @Transactional
+    public void updateMyInfo(User user, PatchMyInfoRequest request) {
+        user.updateEmail(request.getEmail());
+        user.updatePhoneNumber(request.getPhoneNumber());
+        user.updateNickname(request.getNickname());
+        user.updateAddress(request.getAddress());
+        user.updateLocation(request.getLatitude(), request.getLongitude());
+        userRepository.save(user);
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -143,4 +143,10 @@ public class UserService {
         user.updateLocation(request.getLatitude(), request.getLongitude());
         userRepository.save(user);
     }
+
+    @Transactional
+    public void deleteUser(User user) {
+        user.delete();
+        userRepository.save(user);
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -154,7 +154,7 @@ public class UserService {
         user.updateEmail(request.getEmail());
         user.updatePhoneNumber(request.getPhoneNumber());
         user.updateNickname(request.getNickname());
-        user.updateAddress(request.getAddress());
+        user.updateAddress(request.getAddress().getMainAddress(), request.getAddress().getDetailAddress(), request.getAddress().getZipcode());
         user.updateLocation(request.getLatitude(), request.getLongitude());
         userRepository.save(user);
     }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.snackoverflow.toolgether.domain.user.service;
 
+import com.snackoverflow.toolgether.domain.postimage.entity.PostImage;
 import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
 import org.springframework.transaction.annotation.Transactional;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
@@ -132,6 +133,20 @@ public class UserService {
         return userRepository.findByUsername(username).orElseThrow(
                 () -> new ServiceException("404-1", "해당 유저를 찾을 수 없습니다")
         );
+    }
+
+    @Transactional
+    public void postProfileImage(User user, String uuid) {
+        user.updateProfileImage(uuid);
+        userRepository.save(user);
+
+    }
+
+    @Transactional
+    public void deleteProfileImage(User user) {
+        user.deleteProfileImage();
+        userRepository.save(user);
+
     }
 
     @Transactional

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/init/BaseInitData.java
@@ -70,7 +70,7 @@ public class BaseInitData {
 			.address(new Address("서울", "강남구", "12345")) // Address 객체 생성 및 설정
 			.username("human123")
 			.nickname("사람이")
-			.password("1234")
+			.password("12345678")
 			.score(30)
 			.phoneNumber("01012345678")
 			.latitude(37.5665)
@@ -92,7 +92,7 @@ public class BaseInitData {
 			.address(new Address("부산", "해운대구", "67890"))
 			.username("seaman222")
 			.nickname("바다사람")
-			.password("5678")
+			.password("56781234")
 			.score(50)
 			.phoneNumber("01098765432")
 			.latitude(35.1587)

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/util/Util.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/util/Util.java
@@ -1,0 +1,21 @@
+package com.snackoverflow.toolgether.global.util;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.UUID;
+
+public class Util {
+    //UUID를 Base64로 더 짧은 문자열로 표현
+    public static String generateUUIDMasking() {
+        try {
+            UUID uuid = UUID.randomUUID();
+            ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+            bb.putLong(uuid.getMostSignificantBits());
+            bb.putLong(uuid.getLeastSignificantBits());
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(bb.array()).replace("-", "");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,8 @@ jwt:
   secret: [change]
   expiration: 86400000 # 24시간(초 단위)
 
+spring:
+  
   security:
     oauth2:
       client:
@@ -24,7 +26,6 @@ jwt:
           google:
             issuer-uri: https://accounts.google.com
 
-spring:
   jackson:
     serialization:
       fail-on-empty-beans: false

--- a/backend/src/test/java/com/snackoverflow/toolgether/MypageControllerTest.java
+++ b/backend/src/test/java/com/snackoverflow/toolgether/MypageControllerTest.java
@@ -7,11 +7,12 @@ import com.snackoverflow.toolgether.domain.reservation.entity.ReservationStatus;
 import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
 import com.snackoverflow.toolgether.domain.review.service.ReviewService;
 import com.snackoverflow.toolgether.domain.user.controller.MypageController;
-import com.snackoverflow.toolgether.domain.user.dto.AddressInfo;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.MyReservationInfoResponse;
+import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
 import com.snackoverflow.toolgether.domain.user.entity.Address;
 import com.snackoverflow.toolgether.domain.user.entity.User;
+import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,10 +21,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,8 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -165,5 +171,60 @@ public class MypageControllerTest {
 
 		verify(reservationService, times(1)).getRentalReservations(2L);
 		verify(reservationService, times(1)).getBorrowReservations(2L);
+	}
+
+	@Test
+	@DisplayName("내 정보 수정")
+	void testPatchMyInfo() throws Exception {
+
+		String modifiedEmail = "modifiedMail123@gmail.com";
+		String modifiedNickname = "수정된닉네임";
+		String modifiedPhoneNumber = "01012345678";
+		String mainAddress = "수정시 수정구";
+		String detailAddress = "수정동 123-45";
+		String zipcode = "12345";
+		String longitude = "122.2222";
+		String latitude = "44.4444";
+
+		String requestBody = """
+                {
+                    "email": "%s",
+                    "phoneNumber": "%s",
+                    "nickname": "%s",
+                    "address": {
+                        "mainAddress": "%s",
+                        "detailAddress": "%s",
+                        "zipcode": "%s"
+                    },
+                    "longitude": "%s",
+                    "latitude": "%s"
+                }
+                """.formatted(
+				modifiedEmail,
+				modifiedPhoneNumber,
+				modifiedNickname,
+				mainAddress,
+				detailAddress,
+				zipcode,
+				longitude,
+				latitude
+		).stripIndent();
+
+		// When
+		ResultActions resultActions = mockMvc
+				.perform(
+						patch("/api/v1/mypage/me")
+								.content(requestBody)
+								.contentType(
+										new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+								)
+				)
+				.andDo(print());
+
+		// Then
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.code").value("200-1"))
+				.andExpect(jsonPath("$.msg").value("내 정보 수정 성공"));
 	}
 }

--- a/backend/src/test/java/com/snackoverflow/toolgether/MypageControllerTest.java
+++ b/backend/src/test/java/com/snackoverflow/toolgether/MypageControllerTest.java
@@ -2,6 +2,7 @@ package com.snackoverflow.toolgether;
 
 import com.snackoverflow.toolgether.domain.post.entity.Post;
 import com.snackoverflow.toolgether.domain.postimage.service.PostImageService;
+import com.snackoverflow.toolgether.domain.reservation.dto.ReservationRequest;
 import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
 import com.snackoverflow.toolgether.domain.reservation.entity.ReservationStatus;
 import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
@@ -39,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -210,7 +212,6 @@ public class MypageControllerTest {
 				latitude
 		).stripIndent();
 
-		// When
 		ResultActions resultActions = mockMvc
 				.perform(
 						patch("/api/v1/mypage/me")
@@ -221,10 +222,26 @@ public class MypageControllerTest {
 				)
 				.andDo(print());
 
-		// Then
 		resultActions
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.code").value("200-1"))
 				.andExpect(jsonPath("$.msg").value("내 정보 수정 성공"));
+
+		verify(userService, times(1)).updateMyInfo(any(), any());
+
+	}
+
+	@Test
+	@DisplayName("회원 탈퇴")
+	void testDeleteMe() throws Exception {
+
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/mypage/me"))
+				.andDo(print());
+
+		resultActions
+				.andExpect(status().isOk());
+
+		verify(userService, times(1)).deleteUser(any());
+
 	}
 }


### PR DESCRIPTION
✅ Check List
회원정보 수정 api
회원탈퇴 api - 탈퇴 시 논리삭제를 진행하고 기존 유저 데이터에 마스킹 기능을 추가
프로필 등록/수정, 삭제 api
oauth2를 제대로 가져오도록 application.yml경로를 수정

+ 📸 Screenshot or Test Result
![1](https://github.com/user-attachments/assets/90ccba5a-d007-42f3-bf08-312a95e16f08)
![2](https://github.com/user-attachments/assets/c5f83186-e369-423e-826a-c55e2b035b34)
![3](https://github.com/user-attachments/assets/100ee3dc-e82f-4b12-bedf-3470c99482dc)
![4](https://github.com/user-attachments/assets/d2aeabe2-deb5-4c6a-a5d6-9e4550413d04)


## 🔗 Related Issues 
[[FEAT] 백엔드 마이페이지 개인정보 수정 및 삭제 로직 구현](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/32)

## 📝 Note (주의 사항) 
oauth2를 제대로 가져오도록 application.yml경로를 수정했습니다.