### PR TITLE
✨ feat: 위치 검증 로직 구현 및 호출 오류 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.geolatte:geolatte-geom:1.9.0'
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.91.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/KakaoGeoResponse.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/KakaoGeoResponse.java
@@ -1,0 +1,42 @@
+package com.snackoverflow.toolgether.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class KakaoGeoResponse {
+
+    @JsonProperty("documents")
+    private List<Document> documents;
+
+    @JsonProperty("meta")
+    private Meta meta;
+
+    @Data
+    public static class Document {
+
+        @JsonProperty("address_name")
+        private String addressName;
+
+        @JsonProperty("x")
+        private String longitude;
+
+        @JsonProperty("y")
+        private String latitude;
+    }
+
+    @Data
+    public static class Meta {
+
+        @JsonProperty("is_end")
+        private boolean isEnd;
+
+        @JsonProperty("pageable_count")
+        private int pageableCount;
+
+        @JsonProperty("total_count")
+        private int totalCount;
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.snackoverflow.toolgether.domain.user.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/SecurityConfig.java
@@ -32,7 +32,7 @@ class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(authorize ->
                         authorize
-                                .requestMatchers("/login/oauth2/code/google", "/api/v1/users/login", "/h2-console/**").permitAll() // 특정 경로만 허용
+                                .requestMatchers("/login/oauth2/code/google", "/api/v1/users/login", "/h2-console/**", "/oauth/users/additional-info").permitAll() // 특정 경로만 허용
                                 .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/location/AddressConversionException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/location/AddressConversionException.java
@@ -1,0 +1,8 @@
+package com.snackoverflow.toolgether.global.exception.custom.location;
+
+// 주소 변환 관련 예외
+public class AddressConversionException extends LocationException{
+    public AddressConversionException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/location/DistanceCalculationException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/location/DistanceCalculationException.java
@@ -1,0 +1,8 @@
+package com.snackoverflow.toolgether.global.exception.custom.location;
+
+// 거리 계산 관련 예외
+public class DistanceCalculationException extends LocationException {
+    public DistanceCalculationException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/location/LocationException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/custom/location/LocationException.java
@@ -1,0 +1,12 @@
+package com.snackoverflow.toolgether.global.exception.custom.location;
+
+// 공통 상위 클래스
+public class LocationException extends RuntimeException {
+    public LocationException(String message) {
+        super(message);
+    }
+
+    public LocationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/handler/GlobalExceptionHandler.java
@@ -2,6 +2,9 @@ package com.snackoverflow.toolgether.global.exception.handler;
 
 import com.snackoverflow.toolgether.global.exception.custom.CustomException;
 import com.snackoverflow.toolgether.global.exception.custom.duplicate.DuplicateFieldException;
+import com.snackoverflow.toolgether.global.exception.custom.location.AddressConversionException;
+import com.snackoverflow.toolgether.global.exception.custom.location.DistanceCalculationException;
+import com.snackoverflow.toolgether.global.exception.custom.location.LocationException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.CustomAuthException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.MailPreparationException;
 import com.snackoverflow.toolgether.global.exception.custom.mail.SmtpConnectionException;
@@ -14,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -92,10 +94,19 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleService(UserNotFoundException exception) {
-        return ResponseEntity.status(404).body(ErrorResponse.of(
-                "USER-NOT-FOUND", exception.getMessage()
-        ));
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex) {
+        log.error("사용자 찾기 실패: {}", ex.getMessage());
+        return ResponseEntity.status(404).body(
+                ErrorResponse.of("USER_NOT_FOUND", ex.getMessage()));
+    }
+
+    @ExceptionHandler(LocationException.class)
+    public ResponseEntity<ErrorResponse> handleLocationException(LocationException exception) {
+        String errorCode = exception instanceof AddressConversionException ? "ADDRESS_CONVERSION_ERROR"
+                : exception instanceof DistanceCalculationException ? "DISTANCE_CALCULATION_ERROR"
+                : "LOCATION_ERROR";
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                ErrorResponse.of(errorCode, exception.getMessage()));
     }
 
     @ExceptionHandler(CustomException.class)

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.snackoverflow.toolgether.global.filter;
 
-import com.snackoverflow.toolgether.global.exception.custom.mail.CustomAuthException;
 import com.snackoverflow.toolgether.global.util.JwtUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -10,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -20,8 +18,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
-
-import static com.snackoverflow.toolgether.global.exception.custom.mail.CustomAuthException.AuthErrorType.MALFORMED_TOKEN;
 
 @Slf4j
 @Component
@@ -64,5 +60,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 토큰이 없어도 게시물은 조회할 수 있도록
             filterChain.doFilter(request, response);
         }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        return requestURI.startsWith("/h2-console") || requestURI.matches(".*\\.(css|js|gif|png|jpg|ico)$");
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,7 @@ server:
   port: 8080
   servlet:
     session:
+      persistent: true
       timeout: 15m
 jwt:
   secret: [change]
@@ -22,8 +23,8 @@ spring:
       client:
         registration:
           google:
-            client-id: [ change ]
-            client-secret: [ change ]
+            client-id: [change]
+            client-secret: [change]
             redirect-uri: http://localhost:3000/redirect
             scope:
               - openid
@@ -62,8 +63,8 @@ spring:
     open-in-view: false
 
   mail:
-    username: writeyourmail0123@gmail.com
-    password: writeAppPassword
+    username: [change]
+    password: [change]
     host: smtp.gmail.com
     port: 587
     properties:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,13 +7,23 @@ jwt:
   secret: [change]
   expiration: 86400000 # 24시간(초 단위)
 
+kakao:
+  rest:
+    api:
+      key: [change]
+
+spring:
+  jackson:
+    serialization:
+      fail-on-empty-beans: false
+
   security:
     oauth2:
       client:
         registration:
           google:
-            client-id: [change]
-            client-secret: [change]
+            client-id: [ change ]
+            client-secret: [ change ]
             redirect-uri: http://localhost:3000/redirect
             scope:
               - openid
@@ -23,11 +33,6 @@ jwt:
         provider:
           google:
             issuer-uri: https://accounts.google.com
-
-spring:
-  jackson:
-    serialization:
-      fail-on-empty-beans: false
 
   output:
     ansi:
@@ -71,6 +76,3 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
-
-
-

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useRouter} from 'next/navigation';
 import {useAuth} from "@/app/lib/auth-context";
 import {motion} from 'framer-motion';
@@ -13,6 +13,7 @@ export default function LoginPage() {
     const [error, setError] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const {login} = useAuth();
+    const hasFetched = useRef(false);
 
 
     // 폼 제출 핸들러
@@ -56,7 +57,8 @@ export default function LoginPage() {
         const urlParams = new URLSearchParams(window.location.search);
         const authCode = urlParams.get('code');
 
-        if (authCode) {
+        if (authCode && !hasFetched.current) {
+            hasFetched.current = true;
             fetch('http://localhost:8080/login/oauth2/code/google', {
                 method: 'POST',
                 credentials: 'include',


### PR DESCRIPTION
## ✅ Check List
- 코드에 주석 추가 완료
- 카카오 API 키 발급해 application.yml 파일에 추가 (실제 코드는 슬랙으로 공유)
- 위치 검증 서비스 로직 구현
- 위치 검증 컨트롤러 구현 (추가 정보 입력 컨트롤러 내부에 존재)

## 🔍 Test 
<img width="1171" alt="스크린샷 2025-03-08 오후 9 50 27" src="https://github.com/user-attachments/assets/c96f4508-b73d-4e68-afc1-304a0ad8364d" />
- 프론트에서 소셜 로그인 할 때 두 번 요청하던 오류 같이 수정했습니다. 이제 로그로도 토큰 한 번만 확인 되실 거예요!

<img width="1065" alt="스크린샷 2025-03-08 오후 3 37 56" src="https://github.com/user-attachments/assets/25354184-73a3-4d7a-8709-d26ba0dc39fa" />
- 프론트엔드에서 넘어오는 것이 사용자가 입력한 주소, 브라우저 위치 기반 위도와 경도가 넘어옵니다
- 사용자가 입력한 주소를 기반으로 좌표로 변환하려고 하면 위의 사진처럼 전체 정보 넘어옵니다

![KakaoTalk_Photo_2025-03-08-22-14-34](https://github.com/user-attachments/assets/27707c97-9b22-473a-809f-384d43e17945)
![KakaoTalk_Photo_2025-03-08-22-14-38](https://github.com/user-attachments/assets/9b138c3e-6afc-48a9-840c-02c98f0b0436)
- 브라우저의 위치와 본인이 입력한 위치가 5km 이내로 일치하면 true, 아니면 false 반환 

<img width="530" alt="스크린샷 2025-03-08 오후 7 05 59" src="https://github.com/user-attachments/assets/30dc8d09-36a2-4f91-82ec-bb479ca3c673" />
<img width="733" alt="스크린샷 2025-03-08 오후 5 11 40" src="https://github.com/user-attachments/assets/31740aed-ad65-46b0-913b-5f62c165527d" />

- 위치 정보가 일치하지 않으면 오류 발생하고 가입 진행되지 않습니다
- 일치하면 가입 진행되고 메인 페이지로 이동합니다

## 🔗 Related Issues 
[[FEAT] 위치 검증 로직 구현 #34 ](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/34)

## 📝 Note (주의 사항) 
- 프론트에서 오류 처리하는 부분, 가입이 허용되었을 때 추가해야 할 오류 처리와 반환 처리들 수정할 예정입니다
- 프론트 추가 정보 입력 창도 곧 수정하도록 할게요! 
- 꼭 슬랙에서 카카오 API 키 복사하셔서 붙여넣고 실행해 주세요