### PR TITLE
✨ feat: 마이페이지 수정 화면 및 프로필 업로드, 삭제, 회원탈퇴 구현과 S3 bucket 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 	implementation 'org.springframework.session:spring-session-core'
 	annotationProcessor 'org.projectlombok:lombok'
+	//s3 bucket
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
@@ -62,6 +64,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.geolatte:geolatte-geom:1.9.0'
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.91.Final:osx-aarch_64'
+}
+
+dependencyManagement { // Spring Cloud Version 명시 (Hoxton.SR6)
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:Hoxton.SR6"
+	}
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/MypageController.java
@@ -14,11 +14,11 @@ import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 import com.snackoverflow.toolgether.global.filter.CustomUserDetails;
 import com.snackoverflow.toolgether.global.filter.Login;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,7 +38,7 @@ public class MypageController {
     //내 정보 조회
     @GetMapping("/me")
     public RsData<MeInfoResponse> getMyInfo(
-            @Login CustomUserDetails customUserDetails
+        @Login CustomUserDetails customUserDetails
     ) {
         String username = customUserDetails.getUsername();
         User user = userService.findByUsername(username);
@@ -56,7 +56,7 @@ public class MypageController {
     @Transactional(readOnly = true)
     @GetMapping("/reservations")
     public RsData<Map<String, List<MyReservationInfoResponse>>> getMyReservations(
-            @Login CustomUserDetails customUserDetails
+        @Login CustomUserDetails customUserDetails
     ) {
         String username = customUserDetails.getUsername();
         User user = userService.findByUsername(username);
@@ -105,11 +105,12 @@ public class MypageController {
     @PostMapping("/profile")
     public RsData<Void> postProfileimage(
             @Login CustomUserDetails customUserDetails,
-            @RequestBody @NotNull @Validated ProfileRequest profileRequest
+            @Validated ProfileRequest profileRequest,
+            @RequestParam("profileImage") MultipartFile profileImage
     ) {
         String username = customUserDetails.getUsername();
         User user = userService.findByUsername(username);
-        userService.postProfileImage(user, profileRequest.getUuid());
+        userService.postProfileImage(user, profileImage);
         return new RsData<>(
                 "200-1",
                 "프로필 이미지 업로드가 완료되었습니다"

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MeInfoResponse.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/MeInfoResponse.java
@@ -14,6 +14,8 @@ public record MeInfoResponse(
         String email,
         @NonNull String phoneNumber,
         @NonNull AddressInfo address,
+        @NonNull Double latitude,
+        @NonNull Double longitude,
         @NonNull LocalDateTime createdAt,
         @NonNull Integer score,
         @NonNull Integer credit
@@ -27,6 +29,8 @@ public record MeInfoResponse(
                 user.getEmail(),
                 user.getPhoneNumber(),
                 AddressInfo.from(user.getAddress()),
+                user.getLatitude(),
+                user.getLongitude(),
                 user.getCreatedAt(),
                 user.getScore(),
                 user.getCredit()

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/ProfileRequest.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/ProfileRequest.java
@@ -1,12 +1,14 @@
 package com.snackoverflow.toolgether.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @Getter
 public class ProfileRequest {
-    @NotBlank
-    private String uuid;
+    @NotNull
+    private MultipartFile profileImage;
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/entity/User.java
@@ -64,7 +64,7 @@ public class User {
     private boolean additionalInfoRequired = true; // 추가 정보 필요 플래그
 
     @Column(nullable = true)
-    private String profileImage; // 사용자 프로필 이미지, uuid로 저장
+    private String profileImage; // 사용자 프로필 이미지 링크 저장
 
     @Builder.Default
     private int score = 30; // 유저 평가 정보: 기본값 30점

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/AwsConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/AwsConfig.java
@@ -1,4 +1,32 @@
-package com.snackoverflow.toolgether.global.config;
+package com.snackoverflow.toolgether.config;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class AwsConfig {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey); // AWS 자격 증명 생성
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials)) // 자격 증명 설정
+                .withRegion(region) // 리전 설정
+                .build(); // AmazonS3Client Bean 생성
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/AwsConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/AwsConfig.java
@@ -1,0 +1,4 @@
+package com.snackoverflow.toolgether.global.config;
+
+public class AwsConfig {
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/FileUploadException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/FileUploadException.java
@@ -1,0 +1,4 @@
+package com.snackoverflow.toolgether.global.exception;
+
+public class FileUploadException {
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/exception/FileUploadException.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/exception/FileUploadException.java
@@ -1,4 +1,13 @@
 package com.snackoverflow.toolgether.global.exception;
 
-public class FileUploadException {
+import lombok.Getter;
+
+@Getter
+public class FileUploadException extends RuntimeException { // RuntimeException 직접 상속
+    private final String code;
+
+    public FileUploadException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3Service.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3Service.java
@@ -1,4 +1,8 @@
 package com.snackoverflow.toolgether.global.util.s3;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public interface S3Service {
+    String upload(MultipartFile multipartFile, String dirName);
+    void delete(String imageUrl);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3Service.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3Service.java
@@ -1,0 +1,4 @@
+package com.snackoverflow.toolgether.global.util.s3;
+
+public interface S3Service {
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3ServiceImpl.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3ServiceImpl.java
@@ -1,0 +1,4 @@
+package com.snackoverflow.toolgether.global.util.s3;
+
+public class S3ServiceImpl {
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3ServiceImpl.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3ServiceImpl.java
@@ -1,4 +1,51 @@
 package com.snackoverflow.toolgether.global.util.s3;
 
-public class S3ServiceImpl {
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.snackoverflow.toolgether.global.exception.FileUploadException; // FileUploadException import 유지
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String upload(MultipartFile multipartFile, String dirName) {
+        String filename = dirName + "/" + UUID.randomUUID();
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try {
+            PutObjectRequest request = new PutObjectRequest(bucketName, filename, multipartFile.getInputStream(), objectMetadata);
+            amazonS3Client.putObject(request);
+        } catch (IOException e) {
+            throw new FileUploadException("500", "파일 업로드에 실패했습니다."); // HttpStatus.INTERNAL_SERVER_ERROR 전달
+        }
+
+        return amazonS3Client.getUrl(bucketName, filename).toString();
+    }
+
+    public void delete(String imageUrl) {
+        String filename = extractFilenameFromUrl(imageUrl);
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucketName, filename);
+        amazonS3Client.deleteObject(deleteObjectRequest);
+    }
+
+    private String extractFilenameFromUrl(String imageUrl) {
+        String[] parts = imageUrl.split("/");
+        return parts[3] + "/" + parts[4];
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -77,3 +77,15 @@ logging:
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
+
+#AWS S3
+cloud:
+  aws:
+    credentials:
+      access-key: [change]
+      secret-key: [change]
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: toolgetherbucket
+

--- a/frontend/app/mypage/ClientPage.tsx
+++ b/frontend/app/mypage/ClientPage.tsx
@@ -6,6 +6,7 @@ import "moment/locale/ko";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import { useMemo, useState } from "react";
 import ScoreIcon from "../lib/util/scoreIcon";
+import Link from "next/link";
 
 export default function ClientPage({
   me,
@@ -84,16 +85,16 @@ export default function ClientPage({
     ];
     return colors[Math.floor(Math.random() * colors.length)];
   };
-
   const scheduleReservations = {
-    rentals: reservations.rentals.filter((rental) => {
-      rental.status === "APPROVED" || rental.status === "IN_PROGRESS";
-    }),
-    borrows: reservations.borrows.filter((borrow) => {
-      borrow.status === "APPROVED" || borrow.status === "IN_PROGRESS";
-    }),
+    rentals: reservations.rentals.filter(
+      (rental) =>
+        rental.status === "APPROVED" || rental.status === "IN_PROGRESS"
+    ),
+    borrows: reservations.borrows.filter(
+      (borrow) =>
+        borrow.status === "APPROVED" || borrow.status === "IN_PROGRESS"
+    ),
   };
-
   const rentalEvents = scheduleReservations.rentals.map((rental) => ({
     id: rental.id,
     title: `빌리기: ${rental.title}`,
@@ -101,7 +102,6 @@ export default function ClientPage({
     end: moment(rental.endTime).toDate(),
     color: getRandomColor(),
   }));
-
   const borrowEvents = scheduleReservations.borrows.map((borrow) => ({
     id: borrow.id,
     title: `빌려주기: ${borrow.title}`,
@@ -156,7 +156,14 @@ export default function ClientPage({
   return (
     <div className="relative min-h-screen bg-gray-100">
       <div className="container mx-auto px-4 py-4">
-        <h1 className="text-2xl font-bold text-gray-800">마이페이지</h1>
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-800">마이페이지</h1>
+          <Link href="/mypage/edit">
+            <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+              마이페이지 수정
+            </button>
+          </Link>
+        </div>
         <div className="grid grid-cols-1 gap-4 mt-4">
           {/* 유저 정보 */}
           <div className="bg-white shadow-md p-4">
@@ -170,12 +177,15 @@ export default function ClientPage({
                 <span className="font-bold">전화번호: </span>
                 {me.phoneNumber}
               </p>
-              {me?.username ? <p className="text-gray-800">
-                <span className="font-bold">아이디: </span> {me.username}
-              </p> :
-              <p className="text-gray-800">
-                <span className="font-bold">이메일: </span> {me.email}
-              </p>}
+              {me?.username ? (
+                <p className="text-gray-800">
+                  <span className="font-bold">아이디: </span> {me.username}
+                </p>
+              ) : (
+                <p className="text-gray-800">
+                  <span className="font-bold">이메일: </span> {me.email}
+                </p>
+              )}
               <p className="text-gray-800">
                 <span className="font-bold">주소: </span>{" "}
                 {me.address.mainAddress} {me.address.detailAddress} (
@@ -189,7 +199,12 @@ export default function ClientPage({
                 <span className="flex flex-row">
                   <span className="font-bold">평점: </span>
                   {me.score}
-                  <ScoreIcon className="ml-2" score={me.score} size={25} round />
+                  <ScoreIcon
+                    className="ml-2"
+                    score={me.score}
+                    size={25}
+                    round
+                  />
                 </span>
               </p>
               <p className="text-gray-800">
@@ -262,12 +277,14 @@ export default function ClientPage({
                           {reservation.title}
                         </h3>
                         <p className="text-gray-600">
-                          대여: {moment(reservation.startTime).format(
+                          대여:{" "}
+                          {moment(reservation.startTime).format(
                             "YYYY년MM월DD일 HH시mm분"
                           )}
                         </p>
                         <p className="text-gray-600">
-                          반납: {moment(reservation.endTime).format(
+                          반납:{" "}
+                          {moment(reservation.endTime).format(
                             "YYYY년MM월DD일 HH시mm분"
                           )}
                         </p>

--- a/frontend/app/mypage/edit/ClientPage.tsx
+++ b/frontend/app/mypage/edit/ClientPage.tsx
@@ -1,0 +1,561 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation"; // useRouter 훅 import
+
+export default function ClientPage({
+  me,
+}: {
+  me: {
+    id: number;
+    nickname: string;
+    username: string;
+    profileImage: string;
+    email: string;
+    phoneNumber: string;
+    address: {
+      mainAddress: string;
+      detailAddress: string;
+      zipcode: string;
+    };
+    latitude: number;
+    longitude: number;
+    createdAt: string;
+    score: number;
+    credit: number;
+  } | null;
+}) {
+  const [nickname, setNickname] = useState(me?.nickname || "");
+  const [email, setEmail] = useState(me?.email || "");
+  const [phoneNumber, setPhoneNumber] = useState(me?.phoneNumber || "");
+  const [mainAddress, setMainAddress] = useState(
+    me?.address?.mainAddress || ""
+  );
+  const [detailAddress, setDetailAddress] = useState(
+    me?.address?.detailAddress || ""
+  );
+  const [zipcode, setZipcode] = useState(me?.address?.zipcode || "");
+  const [latitude, setLatitude] = useState(me?.latitude || "");
+  const [longitude, setLongitude] = useState(me?.longitude || "");
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<boolean>(false);
+  const [validationErrors, setValidationErrors] = useState<{
+    nickname?: string;
+    email?: string;
+    phoneNumber?: string;
+    mainAddress?: string;
+    detailAddress?: string;
+    zipcode?: string;
+    latitude?: string;
+    longitude?: string;
+  }>({});
+
+  const router = useRouter();
+
+  // 유효성 검사
+  const validateNickname = (value: string) => {
+    if (!value) {
+      return "닉네임을 입력해주세요.";
+    }
+    if (!/^[가-힣]{4,10}$/.test(value)) {
+      return "닉네임은 한글 4~10자로 입력해주세요.";
+    }
+    return "";
+  };
+
+  const validateEmail = (value: string) => {
+    if (!value) {
+      return "이메일을 입력해주세요.";
+    }
+    if (!/\S+@\S+\.\S+/.test(value)) {
+      return "유효한 이메일 주소를 입력해주세요.";
+    }
+    return "";
+  };
+
+  const validatePhoneNumber = (value: string) => {
+    if (!value) {
+      return "전화번호를 입력해주세요.";
+    }
+    if (!/^\d+$/.test(value)) {
+      // 정규식 수정: 하이픈 제외, 숫자만 허용
+      return "전화번호는 하이픈 없이 숫자만 입력해주세요.";
+    }
+    return "";
+  };
+
+  const validateMainAddress = (value: string) => {
+    if (!value) {
+      return "주소를 입력해주세요.";
+    }
+    return "";
+  };
+
+  const validateDetailAddress = (value: string) => {
+    if (!value) {
+      return "상세주소를 입력해주세요.";
+    }
+    return "";
+  };
+
+  const validateZipcode = (value: string) => {
+    if (!value) {
+      return "우편번호를 입력해주세요.";
+    }
+    return "";
+  };
+  const validateLatitude = (value: string) => {
+    if (!value) {
+      return "위도를 입력해주세요."; // 위도 필수 입력으로 변경
+    }
+    if (isNaN(Number(value))) {
+      return "위도는 숫자 형식으로 입력해주세요.";
+    }
+    return "";
+  };
+
+  const validateLongitude = (value: string) => {
+    if (!value) {
+      return "경도를 입력해주세요."; // 경도 필수 입력으로 변경
+    }
+    if (isNaN(Number(value))) {
+      return "경도는 숫자 형식으로 입력해주세요.";
+    }
+    return "";
+  };
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setNickname(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      nickname: validateNickname(value),
+    }));
+  };
+
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setEmail(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      email: validateEmail(value),
+    }));
+  };
+
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setPhoneNumber(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      phoneNumber: validatePhoneNumber(value),
+    }));
+  };
+
+  const handleMainAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setMainAddress(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      mainAddress: validateMainAddress(value),
+    }));
+  };
+
+  const handleDetailAddressChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = e.target.value;
+    setDetailAddress(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      detailAddress: validateDetailAddress(value),
+    }));
+  };
+  const handleZipcodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setZipcode(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      zipcode: validateZipcode(value),
+    }));
+  };
+
+  const handleLatitudeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setLatitude(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      latitude: validateLatitude(value),
+    }));
+  };
+
+  const handleLongitudeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setLongitude(value);
+    setValidationErrors((prevErrors) => ({
+      ...prevErrors,
+      longitude: validateLongitude(value),
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // 폼 제출 전 전체 유효성 검사
+    const newValidationErrors: any = {
+      nickname: validateNickname(nickname),
+      email: validateEmail(email),
+      phoneNumber: validatePhoneNumber(phoneNumber),
+      mainAddress: validateMainAddress(mainAddress),
+      zipcode: validateZipcode(zipcode),
+      latitude: validateLatitude(latitude.toString()),
+      longitude: validateLongitude(longitude.toString()),
+    };
+    setValidationErrors(newValidationErrors);
+
+    if (Object.values(newValidationErrors).some((error) => error)) {
+      setSubmitError("입력값을 다시 확인해주세요.");
+      setIsSubmitting(false);
+      setSubmitSuccess(false);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+    setSubmitSuccess(false);
+
+    const body = JSON.stringify({
+      nickname,
+      email,
+      phoneNumber,
+      address: {
+        mainAddress,
+        detailAddress,
+        zipcode,
+      },
+      latitude,
+      longitude,
+    });
+    console.log("body: ", body); // body 확인용 로그
+    try {
+      const response = await fetch("http://localhost:8080/api/v1/mypage/me", {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData?.msg ||
+            `마이페이지 수정 실패 (HTTP status: ${response.status})`
+        );
+      }
+
+      const Data = await response.json();
+      if (Data?.code !== "200-1") {
+        throw new Error(`마이페이지 수정 실패: ${Data?.msg}`);
+      }
+
+      setSubmitSuccess(true);
+    } catch (error: any) {
+      console.error("마이페이지 수정 에러:", error);
+      setSubmitError(
+        error.message || "마이페이지 수정 중 오류가 발생했습니다."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const closeModalAndRedirect = () => {
+    setSubmitSuccess(false);
+    router.push("/mypage");
+  };
+
+  return (
+    <div className="relative min-h-screen bg-gray-100">
+      <div className="container mx-auto px-4 py-4 max-w-md">
+        <h1 className="text-2xl font-bold text-gray-800">마이페이지 수정</h1>
+        <div className="grid grid-cols-1 gap-4 mt-4">
+          {/* 유저 정보 수정 폼 */}
+          <div className="bg-white shadow-md p-4">
+            <h2 className="text-lg font-bold text-gray-800">내 정보 수정</h2>
+
+            {submitError && (
+              <div
+                className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
+                role="alert"
+              >
+                <strong className="font-bold">오류!</strong>
+                <span className="block sm:inline"> {submitError}</span>
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="mt-4">
+              {/* 폼 입력 필드들은 이전과 동일 */}
+              <div className="mb-4">
+                <label
+                  htmlFor="nickname"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  닉네임
+                </label>
+                <input
+                  type="text"
+                  id="nickname"
+                  className={`shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+                    validationErrors.nickname ? "border-red-500" : ""
+                  }`}
+                  placeholder="닉네임"
+                  value={nickname}
+                  onChange={handleNicknameChange}
+                />
+                {validationErrors.nickname && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.nickname}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="email"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  이메일
+                </label>
+                <input
+                  type="text"
+                  id="email"
+                  className={`shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+                    validationErrors.email ? "border-red-500" : ""
+                  }`}
+                  placeholder="이메일"
+                  value={email}
+                  onChange={handleEmailChange}
+                />
+                {validationErrors.email && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.email}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="phoneNumber"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  전화번호
+                </label>
+                <input
+                  type="tel"
+                  id="phoneNumber"
+                  className={`shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+                    validationErrors.phoneNumber ? "border-red-500" : ""
+                  }`}
+                  placeholder="전화번호"
+                  value={phoneNumber}
+                  onChange={handlePhoneNumberChange}
+                />
+                {validationErrors.phoneNumber && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.phoneNumber}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="mainAddress"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  주소
+                </label>
+                <input
+                  type="text"
+                  id="mainAddress"
+                  className={`shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+                    validationErrors.mainAddress ? "border-red-500" : ""
+                  }`}
+                  placeholder="주소"
+                  value={mainAddress}
+                  onChange={handleMainAddressChange}
+                />
+                {validationErrors.mainAddress && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.mainAddress}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="detailAddress"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  상세 주소
+                </label>
+                <input
+                  type="text"
+                  id="detailAddress"
+                  className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                  placeholder="상세 주소"
+                  value={detailAddress}
+                  onChange={handleDetailAddressChange}
+                />
+                {validationErrors.detailAddress && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.detailAddress}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="zipcode"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  우편번호
+                </label>
+                <input
+                  type="text"
+                  id="zipcode"
+                  className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                  placeholder="우편번호"
+                  value={zipcode}
+                  onChange={handleZipcodeChange}
+                />
+                {validationErrors.zipcode && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.zipcode}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="latitude"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  위도(임시)
+                </label>
+                <input
+                  type="text"
+                  id="latitude"
+                  className={`shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+                    validationErrors.latitude ? "border-red-500" : ""
+                  }`}
+                  placeholder="위도"
+                  value={latitude}
+                  onChange={handleLatitudeChange}
+                />
+                {validationErrors.latitude && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.latitude}
+                  </p>
+                )}
+              </div>
+              <div className="mb-4">
+                <label
+                  htmlFor="longitude"
+                  className="block text-gray-700 text-sm font-bold mb-2"
+                >
+                  경도(임시)
+                </label>
+                <input
+                  type="text"
+                  id="longitude"
+                  className={`shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline ${
+                    validationErrors.longitude ? "border-red-500" : ""
+                  }`}
+                  placeholder="경도"
+                  value={longitude}
+                  onChange={handleLongitudeChange}
+                />
+                {validationErrors.longitude && (
+                  <p className="text-red-500 text-xs italic mt-1">
+                    {validationErrors.longitude}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex items-center justify-between">
+                <button
+                  className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+                  type="submit"
+                  disabled={isSubmitting} // 요청 중에는 버튼 비활성화
+                >
+                  {isSubmitting ? "수정 중..." : "수정 완료"}
+                </button>
+                <button
+                  type="button"
+                  className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+                  onClick={() => {
+                    // TODO: 취소 버튼 클릭 시 동작 (예: 이전 페이지로 이동)
+                    alert("취소 버튼 클릭!");
+                  }}
+                >
+                  취소
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      {/* 성공 모달 */}
+      {submitSuccess && (
+        <div className="fixed z-10 inset-0 overflow-y-auto">
+          <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div
+              className="fixed inset-0 transition-opacity"
+              aria-hidden="true"
+            >
+              <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
+            </div>
+            <span
+              className="hidden sm:inline-block sm:align-middle sm:h-screen"
+              aria-hidden="true"
+            >
+              &#8203;
+            </span>
+            <div
+              className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="modal-headline"
+            >
+              <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div className="sm:flex sm:items-start">
+                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                    <h3
+                      className="text-lg leading-6 font-medium text-gray-900"
+                      id="modal-headline"
+                    >
+                      수정 완료
+                    </h3>
+                    <div className="mt-2">
+                      <p className="text-sm text-gray-500">
+                        마이페이지 정보가 성공적으로 수정되었습니다.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                <button
+                  type="button"
+                  className="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-blue-500 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm"
+                  onClick={closeModalAndRedirect} // 확인 버튼 클릭 시 모달 닫고 리다이렉트
+                >
+                  확인
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/mypage/edit/page.tsx
+++ b/frontend/app/mypage/edit/page.tsx
@@ -17,6 +17,9 @@ export default async function page() {
 
   // console.log("쿠키에서 가져온 닉네임: ", myParsedData.nickname);
 
+  let userData = null;
+  //마이페이지에서 유저 데이터 가져오기 - 이메일, 닉네임, 전화번호, 주소소
+
   const getMyInfo = await fetch("http://localhost:8080/api/v1/mypage/me", {
     method: "GET",
     credentials: "include",
@@ -25,19 +28,8 @@ export default async function page() {
     },
   });
 
-  const getMyReservations = await fetch(
-    "http://localhost:8080/api/v1/mypage/reservations",
-    {
-      method: "GET",
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    }
-  );
+ 
 
-  let userData = null;
-  let reservationData = null;
 
   if (getMyInfo.ok) {
     const Data = await getMyInfo.json();
@@ -47,16 +39,6 @@ export default async function page() {
     userData = Data.data;
   } else {
     console.error("Error fetching data:", getMyInfo.status);
-  }
-
-  if (getMyReservations.ok) {
-    const Data = await getMyReservations.json();
-    if (Data?.code !== "200-1") {
-      console.error(`에러가 발생했습니다. \n${Data?.msg}`);
-    }
-    reservationData = Data.data;
-  } else {
-    console.error("Error fetching data:", getMyReservations.status);
   }
 
   // const mockUpUser = {
@@ -81,51 +63,10 @@ export default async function page() {
   //   },
   // };
 
-  // const mockUpReservation = {
-  //   result: "200-1",
-  //   data: {
-  //     rentals: [
-  //       {
-  //         id: 1, //reservation id
-  //         title: "전동 드릴",
-  //         image: "image.png",
-  //         amount: 10000,
-  //         startTime: "2025-03-10T10:11:00",
-  //         endTime: "2025-03-12T18:12:00",
-  //         status: "APPROVED",
-  //         isReviewed: false,
-  //       },
-  //       {
-  //         id: 3, //reservation id
-  //         title: "망치",
-  //         image: "image.png",
-  //         amount: 5000,
-  //         startTime: "2025-03-11T11:11:00",
-  //         endTime: "2025-03-14T18:12:00",
-  //         status: "APPROVED",
-  //         isReviewed: false,
-  //       },
-  //     ],
-  //     borrows: [
-  //       {
-  //         id: 2,
-  //         title: "공구 세트",
-  //         image: "image.png",
-  //         amount: 20000,
-  //         startTime: "2025-03-05T09:10:00",
-  //         endTime: "2025-03-07T15:17:00",
-  //         status: "IN_PROGRESS",
-  //         isReviewed: false,
-  //       },
-  //     ],
-  //   },
-  // };
-
   // const me = mockUpUser.data;
   const me = userData;
-  const reservations = reservationData;
 
-  return <ClientPage me={me} reservations={reservations} />;
+  return <ClientPage me={me} />;
 }
 
 function parseAccessToken(accessToken: RequestCookie | undefined) {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 
+/** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
   /* config options here */
 };
@@ -7,17 +8,29 @@ const nextConfig: NextConfig = {
 export default nextConfig;
 
 module.exports = {
-    async headers() {
-        return [
-            {
-                source: '/(.*)',
-                headers: [
-                    {
-                        key: 'Access-Control-Allow-Origin',
-                        value: 'https://dapi.kakao.com',
-                    }
-                ]
-            }
-        ]
-    }
-}
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "https://dapi.kakao.com",
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = {
+    images: {
+      remotePatterns: [
+        {
+          protocol: 'https',
+          hostname: 'toolgetherbucket.s3.ap-northeast-2.amazonaws.com',
+          port: '',
+          pathname: '/profile/**',
+        },
+      ],
+    }}


### PR DESCRIPTION
✨ 구현 내용
마이페이지 조회 화면
-내 정보 수정 버튼 추가 및 api 연동
-프로필 이미지 추가 및 api s3 버켓 적용 후 연동
-프로필 이미지 등록, 삭제 버튼 추기 및 api s3 버켓 적용 후 연동

마이페이지 수정 
-화면 추가 및 수정 api 연동

## 🔍 Test 
![이미지 등록, 수정](https://github.com/user-attachments/assets/e5b0da0e-293a-4b32-8f8f-2d88a1afa6f5)
![이미지 삭제](https://github.com/user-attachments/assets/de371017-1e8e-413b-a80e-93f08025c5e0)


## 🔗 Related Issues 
[[FEAT] 프론트엔드 마이페이지 수정 화면 및 프로필 업로드, 삭제, 회원탈퇴 구현 #43](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/43)

## 📝 Note (주의 사항) 
application.yml에 accessToken과 secretToken 추가가 필요합니다.
수정 화면에 지도 api가 적용되지 않았습니다. 추후 추가 예정입니다.
마이페이지에 로그인 확인 기능도 추가될 예정입니다.

기존 작성하던 브랜치 코드에 백엔드 기능이 필요해 백엔드도 섞였습니다.
다음부터는 섞이지 않도록 주의하겠습니다.