### PR TITLE
✨ feat: 일반 회원가입 로직 구현 및 프론트 코드 추가 issue: #7

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
@@ -56,18 +56,28 @@ public class UserController {
 
     // 회원 가입
     @PostMapping("/signup")
-    public RsData<User> signup(@RequestBody @Validated SignupRequest request) {
-        // 이메일, 아이디, 닉네임 중복 확인
-        userService.checkDuplicates(request);
+    public RsData<?> signup(@RequestBody @Validated SignupRequest request) {
+        try {
+            // 중복 확인 및 패스워드가 일치하는지 확인
+            userService.checkDuplicates(request);
+            userService.checkPassword(request);
 
-        // 이상 없을 시에 회원 가입 진행
-        userService.registerVerifiedUser(request);
+            // 회원 가입 처리
+            boolean isSuccess = userService.registerVerifiedUser(request);
 
-        return new RsData<>(
-                "201-2",
-                "회원 가입이 완료되었습니다.",
-                userService.getUserForUsername(request.username())
-        );
+            if (isSuccess) {
+                // 회원 정보 조회 및 성공 응답 반환
+                User user = userService.getUserForUsername(request.username());
+                return new RsData<>("201-2", "회원 가입 완료", user);
+            }
+
+            // 위치 검증 실패 응답 반환
+            return new RsData<>("400-1", "위치 검증 실패", null);
+
+        } catch (Exception e) {
+            // 기타 서버 오류 처리
+            return new RsData<>("500-1", "서버 오류", null);
+        }
     }
 
     // 일반 사용자 로그인

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/SignupRequest.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/dto/request/SignupRequest.java
@@ -11,6 +11,10 @@ public record SignupRequest(
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 영문+숫자 조합 8자 이상이어야 합니다")
         String password,
 
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$", message = "비밀번호는 영문+숫자 조합 8자 이상이어야 합니다")
+        String checkPassword,
+
         @Email @NotBlank String email,
         @NotBlank String nickname,
         @NotBlank String phoneNumber,

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/OauthService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/OauthService.java
@@ -63,7 +63,7 @@ public class OauthService {
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {
                 })
-                .block();// 동기 처리 -> 비동기 처리도 가능한지 알아볼 것
+                .block();// 동기 처리
         log.info("Google Token Response: {}", response);
         if (response != null && response.containsKey("access_token")) {
             return response;
@@ -131,7 +131,7 @@ public class OauthService {
     }
 
     // 두 좌표 간의 거리 계산 공식 (Haversine)
-    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+    public double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         final double R = 6371; // 지구 반지름 (km 단위)
 
         double latDistance = Math.toRadians(lat2 - lat1);

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -1,7 +1,11 @@
 package com.snackoverflow.toolgether.domain.user.service;
 
+import com.snackoverflow.toolgether.domain.user.dto.KakaoGeoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.request.PatchMyInfoRequest;
 import com.snackoverflow.toolgether.domain.user.entity.Address;
+import com.snackoverflow.toolgether.global.exception.custom.location.AddressConversionException;
+import com.snackoverflow.toolgether.global.exception.custom.location.DistanceCalculationException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 import com.snackoverflow.toolgether.domain.user.dto.MeInfoResponse;
 import com.snackoverflow.toolgether.domain.user.entity.User;
@@ -16,6 +20,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +36,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final VerificationService verificationService;
     private final JwtUtil jwtUtil;
+    private final WebClient webClient;
+    private final OauthService oauthService;
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoApiKey;
 
     // 이메일, 아이디, 닉네임 중복 방지
     public void checkDuplicates(SignupRequest request) {
@@ -40,6 +52,13 @@ public class UserService {
         }
         if (userRepository.existsByNickname(request.nickname())) {
             throw new DuplicateFieldException("사용자 닉네임 중복 오류 발생");
+        }
+    }
+
+    // 비밀번호 확인 필드
+    public void checkPassword(SignupRequest request) {
+        if (!request.password().equals(request.checkPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
     }
 
@@ -55,39 +74,101 @@ public class UserService {
         }
     }
 
+    // 주소 -> 좌표 변환 메서드 (동기식)
+    public KakaoGeoResponse.Document convertAddressToCoordinate(String baseAddress) {
+        String mapUrl = "https://dapi.kakao.com/v2/local/search/address.json?query=" + baseAddress;
+
+        try {
+            KakaoGeoResponse response =
+                    webClient.get()
+                    .uri(mapUrl)
+                    .header("Authorization", "KakaoAK " + kakaoApiKey)
+                    .retrieve()
+                    .onStatus(
+                            status -> !status.is2xxSuccessful(),
+                            clientResponse -> Mono.error(new AddressConversionException("API 요청 실패: " + clientResponse.statusCode()))
+                    )
+                    .bodyToMono(KakaoGeoResponse.class)
+                    .block();
+
+            if (response != null
+                    && response.getDocuments() != null
+                    && !response.getDocuments().isEmpty()) {
+                return response.getDocuments().getFirst();
+            }
+            throw new AddressConversionException("주소를 좌표로 반환할 수 없습니다.");
+
+        } catch (Exception e) {
+            throw new AddressConversionException("좌표 변환 실패: " + e.getMessage());
+        }
+    }
+
     // 회원 가입
     @Transactional
-    public void registerVerifiedUser(SignupRequest request) {
-        // 이메일 인증 완료 시 회원 가입 허용
+    public boolean registerVerifiedUser(SignupRequest request) {
+        // 이메일 인증 완료 여부 확인
         if (!verificationService.isEmailVerified(request.email())) {
-            throw new VerificationException(VerificationException.ErrorType.NOT_VERIFIED, "인증되지 않은 이메일입니다. 이메일: "+ request.email());
+            throw new VerificationException(
+                    VerificationException.ErrorType.NOT_VERIFIED,
+                    "인증되지 않은 이메일: " + request.email()
+            );
         }
 
-        // 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(request.password());
+        try {
+            // 주소 -> 좌표 변환
+            KakaoGeoResponse.Document converted = convertAddressToCoordinate(request.baseAddress());
+            if (converted == null) {
+                throw new AddressConversionException("주소를 좌표로 반환할 수 없습니다.");
+            }
 
-        // 위치 인증 후 회원 가입 가능
+            double addressLat = Double.parseDouble(converted.getLatitude());
+            double addressLon = Double.parseDouble(converted.getLongitude());
 
+            // 사용자 제공 위치와 주소 변환 위치 비교
+            double distance = oauthService.calculateDistance(
+                    request.latitude(),
+                    request.longitude(),
+                    addressLat,
+                    addressLon
+            );
 
-        //User 엔티티 생성 후 DB 저장
-        User user = User.builder()
-                .username(request.username())
-                .password(request.password())
-                .email(request.email())
-                .nickname(request.nickname())
-                .address(Address.builder()
-                        .zipcode(request.postalCode())
-                        .mainAddress(request.baseAddress())
-                        .detailAddress(request.detailAddress())
-                        .build())
-                .longitude(request.longitude())
-                .latitude(request.latitude())
-                .phoneNumber(request.phoneNumber())
-                .profileImage(null)
-                .additionalInfoRequired(false)
-                .build();
+            // 5km 초과 시 거부
+            if (distance > 5) {
+                log.warn("위치 허용 범위 초과: {} km (요청 위치: {}/{})",
+                        distance, request.latitude(), request.longitude());
+                return false;
+            }
 
-        userRepository.save(user);
+            // 비밀번호 암호화
+            String encodedPassword = passwordEncoder.encode(request.password());
+
+            // 사용자 엔티티 생성
+            User user = User.builder()
+                    .username(request.username())
+                    .password(encodedPassword)
+                    .email(request.email())
+                    .nickname(request.nickname())
+                    .address(Address.builder()
+                            .zipcode(request.postalCode())
+                            .mainAddress(request.baseAddress())
+                            .detailAddress(request.detailAddress())
+                            .build())
+                    .latitude(addressLat) // 변환된 좌표 사용
+                    .longitude(addressLon)
+                    .phoneNumber(request.phoneNumber())
+                    .additionalInfoRequired(false)
+                    .build();
+
+            // 저장 후 성공 신호 반환
+            userRepository.save(user);
+            return true;
+
+        } catch (AddressConversionException e) {
+            log.error("주소 변환 실패: {}", e.getMessage());
+            return false;
+        } catch (NumberFormatException e) {
+            throw new DistanceCalculationException("좌표 파싱 실패: " + e.getMessage());
+        }
     }
 
     // 기본 사용자 로그인

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/VerificationService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/VerificationService.java
@@ -10,12 +10,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class VerificationService {
 
     private final HttpSession session;
@@ -64,6 +66,7 @@ public class VerificationService {
     }
 
     // 인증 코드 확인 후 세션 상태 변경 verified: false -> true
+    @Transactional
     public void verifyEmail(String inputEmail, String inputCode) {
         VerificationData data = (VerificationData) session.getAttribute(SESSION_KEY);
 

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/SecurityConfig.java
@@ -32,7 +32,7 @@ class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(authorize ->
                         authorize
-                                .requestMatchers("/login/oauth2/code/google", "/api/v1/users/login", "/h2-console/**", "/oauth/users/additional-info").permitAll() // 특정 경로만 허용
+                                .requestMatchers("/login/oauth2/code/google", "/api/v1/users/login", "/h2-console/**", "/oauth/users/additional-info", "/api/v1/users/**").permitAll() // 특정 경로만 허용
                                 .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -25,11 +25,11 @@ export default function LoginPage() {
         try {
             const response = await fetch('http://localhost:8080/api/v1/users/login', {
                 method: 'POST',
+                credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify({username, password}),
-                credentials: 'include' // 쿠키 전송 허용
             });
 
             const data = await response.json();

--- a/frontend/app/signup/ClientPage.tsx
+++ b/frontend/app/signup/ClientPage.tsx
@@ -1,0 +1,589 @@
+'use client';
+
+import {useState, useEffect, useRef} from 'react';
+import {useRouter} from 'next/navigation';
+import {motion, AnimatePresence} from 'framer-motion';
+import {
+    EnvelopeIcon,
+    MapPinIcon,
+    UserCircleIcon,
+    LockClosedIcon,
+    DevicePhoneMobileIcon,
+    SparklesIcon,
+    IdentificationIcon,
+    PaperAirplaneIcon,
+    MagnifyingGlassIcon,
+    ExclamationTriangleIcon,
+    ClockIcon
+} from '@heroicons/react/24/outline';
+import {ArrowRightIcon, CheckCircleIcon} from "lucide-react";
+
+type FormData = {
+    username: string;
+    password: string;
+    checkPassword: string;
+    email: string;
+    nickname: string;
+    phoneNumber: string;
+    postalCode: string;
+    baseAddress: string;
+    detailAddress: string;
+    latitude: number;
+    longitude: number;
+    verificationCode: string;
+};
+
+export default function SignupPage() {
+    const router = useRouter();
+    const [currentStep, setCurrentStep] = useState(1);
+    const [countdown, setCountdown] = useState<number>(0);
+    const [, setIsLoading] = useState(false);
+    const [isEmailVerified, setIsEmailVerified] = useState(false);
+    const intervalRef = useRef<NodeJS.Timeout>();
+    const [error, setError] = useState('');
+    const [formData, setFormData] = useState<FormData>({
+        username: '',
+        password: '',
+        checkPassword: '',
+        email: '',
+        nickname: '',
+        phoneNumber: '',
+        postalCode: '',
+        baseAddress: '',
+        detailAddress: '',
+        latitude: 0,
+        longitude: 0,
+        verificationCode: ''
+    });
+
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [, setGeoError] = useState('');
+
+    // 카운트다운 로직
+    useEffect(() => {
+        if (countdown > 0) {
+            intervalRef.current = setInterval(() => {
+                setCountdown((prev) => {
+                    if (prev <= 1) {
+                        clearInterval(intervalRef.current!);
+                        return 0;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+        }
+        return () => {
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+            }
+        };
+    }, [countdown]);
+
+    // 위치 정보 조회
+    useEffect(() => {
+        if (!navigator.geolocation) {
+            setGeoError('브라우저가 위치 서비스를 지원하지 않습니다');
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                setFormData(prev => ({
+                    ...prev,
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude
+                }));
+            },
+            (err) => {
+                setGeoError(`위치 정보 오류: ${err.message}`);
+            }
+        );
+    }, []);
+
+    // 카카오 주소 검색
+    const handleAddressSearch = () => {
+        if (!window.daum) {
+            console.error('카카오 API 로드 실패');
+            return;
+        }
+
+        new window.daum.Postcode({
+            oncomplete: (data) => {
+                setFormData(prev => ({
+                    ...prev,
+                    postalCode: data.zonecode,
+                    baseAddress: `${data.address} ${data.buildingName || ''}`.trim()
+                }));
+            }
+        }).open();
+    };
+
+    // 이메일 인증 요청
+    const handleSendVerificationCode = async () => {
+        try {
+            const response = await fetch('http://localhost:8080/api/v1/users/send-verification-code', {
+                method: 'POST',
+                credentials: 'include',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({email: formData.email})
+            });
+
+            if (!response.ok) throw new Error('인증 코드 전송 실패');
+            setCountdown(900); // 15분 타이머 시작
+            if (intervalRef.current) {
+                clearInterval(intervalRef.current);
+            }
+        } catch (err) {
+            setErrors({email: '인증 코드 전송에 실패했습니다'});
+        }
+    };
+
+    // 인증 코드 확인
+    const handleVerifyEmail = async () => {
+        try {
+            const response = await fetch('http://localhost:8080/api/v1/users/verified-email', {
+                method: 'POST',
+                credentials: 'include',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    email: formData.email,
+                    code: formData.verificationCode
+                })
+            });
+
+            if (!response.ok) throw new Error('인증 실패');
+            setIsEmailVerified(true);
+            setTimeout(() => {
+                setCurrentStep(prev => Math.min(prev + 1, 3)); // 3은 최대 단계 수
+            }, 1000);
+        } catch (err) {
+            setErrors(prev => ({...prev, verification: '인증 코드가 일치하지 않습니다'}));
+        }
+    };
+
+    // 회원 가입 제출
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setIsLoading(true);
+
+        const validationErrors = validateForm();
+        if (Object.keys(validationErrors).length > 0) {
+            setErrors(validationErrors);
+            return;
+        }
+
+        try {
+            const response = await fetch('http://localhost:8080/api/v1/users/signup', {
+                method: 'POST',
+                credentials: 'include',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(formData)
+            });
+
+            const result = await response.json();
+
+            if (!response.ok || result.code === "400-1") {
+                throw {
+                    type: 'LOCATION_ERROR',
+                    message: '위치 정보 오류',
+                    details: {
+                        allowedRadius: 5,
+                    }
+                };
+            }
+
+            if (result.code === '201-2') {
+                alert('🎉 회원 가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
+                router.push('/login');
+            }
+
+        } catch (err) {
+            if (err.type === 'LOCATION_ERROR') {
+            setError(`🗺️ 지역 제한 서비스 안내
+• 현재 위치에서 5km 이내 지역만 서비스 제공`);
+        } else {
+            setError(`⚠️ ${err.message}`);
+        }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const validateForm = () => {
+        const newErrors: { [key: string]: string } = {};
+        if (!formData.email.includes('@')) newErrors.email = '유효한 이메일을 입력해주세요';
+        if (formData.password.length < 8) newErrors.password = '비밀번호는 영문+숫자 조합 8자 이상이어야 합니다';
+        if (formData.verificationCode.length !== 8)
+            newErrors.verificationCode = '인증 코드는 8글자입니다';
+        if (formData.username.length > 20 || formData.username.length < 8) newErrors.username = '사용자 ID는 8~20자로 입력해 주세요';
+        return newErrors;
+    };
+
+    return (
+        <div className="max-w-2xl mx-auto p-6 space-y-8">
+            {/* 단계 표시기 */}
+            <div className="flex items-center justify-center relative mb-12">
+                <div className="flex items-center justify-between w-64">
+                    {[1, 2, 3].map((step) => (
+                        <div key={step} className="relative z-10">
+                            <div
+                                className={`w-10 h-10 rounded-full flex items-center justify-center text-white 
+                                ${currentStep >= step ? 'bg-green-500' : 'bg-gray-300'}`}
+                            >
+                                {step}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+                <div className="absolute top-1/2 left-16 right-16 h-1 bg-gray-200 transform -translate-y-1/2"></div>
+            </div>
+
+            <motion.form
+                onSubmit={handleSubmit}
+                className="space-y-6"
+                initial={{opacity: 0}}
+                animate={{opacity: 1}}
+                transition={{duration: 0.5}}
+            >
+
+                {/* 1단계: 이메일 인증 */}
+
+                <AnimatePresence mode='wait'>
+                    {currentStep === 1 && (
+                        <motion.div
+                            key="step1"
+                            initial={{opacity: 0, x: 50}}
+                            animate={{opacity: 1, x: 0}}
+                            exit={{opacity: 0, x: -50}}
+                            className="space-y-6"
+                        >
+                            <div className="mb-6">
+                                <div className="flex items-center gap-3 mb-2">
+                                    <div className="p-2 bg-green-100 rounded-full">
+                                        <EnvelopeIcon className="w-6 h-6 text-green-600"/>
+                                    </div>
+                                    <h2 className="text-2xl font-bold text-gray-800">이메일 주소 확인</h2>
+                                </div>
+                                <p className="text-sm text-gray-500 ml-11">
+                                    가입을 위해 이메일 인증이 필요합니다
+                                </p>
+                            </div>
+                            <div className="space-y-4">
+                                <div className="relative">
+                                    <input
+                                        type="email"
+                                        className={`w-full p-4 border-2 rounded-lg pl-12 text-gray-700 ${
+                                            errors.email ? 'border-red-500' : 'border-gray-200'
+                                        } focus:outline-none focus:border-green-500`}
+                                        placeholder="example@domain.com"
+                                        value={formData.email}
+                                        onChange={(e) => {
+                                            setFormData({...formData, email: e.target.value})
+                                            setErrors(prev => ({...prev, email: ''}))
+                                        }}
+                                        onBlur={() => {
+                                            if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+                                                setErrors(prev => ({...prev, email: '유효한 이메일 형식이 아닙니다'}))
+                                            }
+                                        }}
+                                    />
+                                    <EnvelopeIcon
+                                        className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"/>
+                                </div>
+
+                                {errors.email && (
+                                    <motion.div
+                                        initial={{opacity: 0, y: -10}}
+                                        animate={{opacity: 1, y: 0}}
+                                        className="flex items-center gap-2 text-red-500 text-sm"
+                                    >
+                                        <ExclamationTriangleIcon className="w-4 h-4"/>
+                                        {errors.email}
+                                    </motion.div>
+                                )}
+                            </div>
+
+                            <button
+                                onClick={handleSendVerificationCode}
+                                disabled={countdown > 0 || !!errors.email}
+                                className={`w-full py-3 rounded-lg font-medium flex items-center justify-center gap-2 ${
+                                    countdown > 0
+                                        ? 'bg-gray-100 text-gray-400'
+                                        : 'bg-green-50 hover:bg-green-100 text-green-700'
+                                }`}
+                            >
+                                {countdown > 0 ? (
+                                    <>
+      <span className="animate-pulse">
+        {`${String(Math.floor(countdown / 60)).padStart(2, '0')}:${String(countdown % 60).padStart(2, '0')}`}
+      </span>
+                                        <ClockIcon className="w-4 h-4 animate-spin"/>
+                                    </>
+                                ) : (
+                                    <>
+                                        <PaperAirplaneIcon className="w-4 h-4 animate-[bounce_1.5s_infinite]"/>
+                                        인증번호 받기
+                                    </>
+                                )}
+                            </button>
+
+                            <motion.div className="space-y-4">
+                                <div className="relative">
+                                    <input
+                                        type="text"
+                                        placeholder="8자리 인증번호 입력"
+                                        className="w-full p-4 border-2 text-gray-700 ${
+                                            errors.verificationCode ? 'border-red-500' : 'border-gray-200'
+                                        } border-gray-200 rounded-lg pl-12 focus:outline-none focus:border-green-500"
+                                        value={formData.verificationCode}
+                                        onChange={(e) => setFormData({...formData, verificationCode: e.target.value})}
+                                    />
+                                    <LockClosedIcon
+                                        className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"/>
+                                </div>
+
+                                {errors.verificationCode && (
+                                    <motion.div
+                                        initial={{opacity: 0, y: -10}}
+                                        animate={{opacity: 1, y: 0}}
+                                        className="flex items-center gap-2 text-red-500 text-sm"
+                                    >
+                                        <ExclamationTriangleIcon className="w-4 h-4"/>
+                                        {errors.verificationCode}
+                                    </motion.div>
+                                )}
+
+                                <button
+                                    onClick={handleVerifyEmail}
+                                    className={`w-full py-3 rounded-lg font-medium flex items-center justify-center gap-2 ${
+                                        isEmailVerified
+                                            ? 'bg-green-400 cursor-not-allowed'
+                                            : 'bg-green-500 hover:bg-green-600 text-white'
+                                    }`}
+                                >
+                                    {isEmailVerified ? (
+                                        <>
+                                            <CheckCircleIcon className="w-5 h-5"/>
+                                            인증 완료
+                                        </>
+                                    ) : (
+                                        '인증 확인'
+                                    )}
+                                </button>
+                            </motion.div>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+
+                {/* 2단계: 주소 입력 */}
+                <AnimatePresence>
+                    {currentStep >= 2 && (
+                        <motion.div
+                            initial={{opacity: 0}}
+                            animate={{opacity: 1}}
+                            className="space-y-4"
+                        >
+
+                            <div className="mb-6">
+                                <div className="flex items-center gap-3 mb-2">
+                                    <div className="p-2 bg-green-100 rounded-full">
+                                        <EnvelopeIcon className="w-6 h-6 text-green-600"/>
+                                    </div>
+                                    <h2 className="text-2xl font-bold text-gray-800">주소 등록</h2>
+                                </div>
+                                <p className="text-sm text-gray-500 ml-11">
+                                    가입을 위해서는 주소 인증이 필요합니다
+                                </p>
+                            </div>
+                            <div className="flex items-center gap-2 mb-4">
+                                <MapPinIcon className="w-6 h-6 text-green-500"/>
+                                <h2 className="text-xl font-semibold text-gray-800">주소 입력</h2>
+                            </div>
+
+                            <AnimatePresence>
+                                {(error) && (
+                                    <motion.div
+                                        initial={{ opacity: 0, y: -20 }}
+                                        animate={{ opacity: 1, y: 0 }}
+                                        exit={{ opacity: 0, y: -20 }}
+                                        className="mb-4 p-4 bg-red-50 border-l-4 border-red-400 rounded-lg"
+                                    >
+                                        <div className="flex items-start"> {/* 왼쪽 정렬을 위한 items-start */}
+                                            <ExclamationTriangleIcon className="h-6 w-6 text-red-500 mt-1 mr-2" />
+                                            <div className="space-y-2 text-left"> {/* 텍스트 왼쪽 정렬 */}
+                                                <pre className="text-sm text-red-700 whitespace-pre-wrap">
+            {error}
+          </pre>
+                                            </div>
+                                        </div>
+                                    </motion.div>
+                                )}
+                            </AnimatePresence>
+
+                            <div className="flex gap-2">
+                                <input
+                                    type="text"
+                                    placeholder="우편번호"
+                                    className="flex-1 p-3 border-2 border-green-100 text-gray-800 rounded-lg bg-gray-50"
+                                    value={formData.postalCode}
+                                    readOnly
+                                />
+                                <motion.button
+                                    type="button"
+                                    whileHover={{scale: 1.05}}
+                                    className="bg-green-500 text-white px-6 py-3 rounded-lg font-medium flex items-center gap-2"
+                                    onClick={handleAddressSearch}
+                                >
+                                    <MagnifyingGlassIcon className="w-5 h-5"/>
+                                    주소 검색
+                                </motion.button>
+                            </div>
+
+                            {formData.baseAddress && (
+                                <motion.div
+                                    initial={{opacity: 0}}
+                                    animate={{opacity: 1}}
+                                    className="space-y-4"
+                                >
+                                    <input
+                                        type="text"
+                                        placeholder="상세 주소"
+                                        className="w-full p-3 border-2 text-gray-800 border-green-100 rounded-lg"
+                                        value={formData.detailAddress}
+                                        onChange={(e) => setFormData({...formData, detailAddress: e.target.value})}
+                                    />
+
+                                    {/* 위치 기반 서비스 설명 툴팁 */}
+                                    <div className="mt-4 p-3 bg-blue-50 rounded-lg border border-blue-200">
+                                        <div className="flex items-start">
+                                            <MapPinIcon className="h-5 w-5 text-green-500 mt-1 mr-2" />
+                                            <div>
+                                                <h3 className="font-medium text-green-800">📍 위치 기반 서비스 안내</h3>
+                                                <p className="text-sm text-green-600 mt-1">
+                                                    당사는 사용자의 정확한 위치 정보를 기반으로 맞춤형 서비스를 제공합니다.
+                                                </p>
+                                                <ul className="list-disc list-inside text-green-600 text-sm mt-2 pl-2">
+                                                    <li>실시간 지역별 예약 가능 안내</li>
+                                                    <li>근처 예약 가능 서비스 제공</li>
+                                                    <li>지역 커뮤니티 연동</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <motion.button
+                                        type="button"
+                                        whileHover={{ scale: 1.05 }}
+                                        whileTap={{ scale: 0.95 }}
+                                        className={`w-full py-3 rounded-lg font-medium flex items-center justify-center gap-2 ${
+                                            formData.postalCode && formData.detailAddress
+                                                ? 'bg-green-500 hover:bg-green-600 text-white'
+                                                : 'bg-gray-300 cursor-not-allowed'
+                                        }`}
+                                        onClick={() => setCurrentStep(3)}
+                                        disabled={!formData.postalCode || !formData.detailAddress}
+                                    >
+                                        <ArrowRightIcon className="w-5 h-5" />
+                                        다음 단계로 이동
+                                    </motion.button>
+                                </motion.div>
+                            )}
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+
+                {/* 3단계: 추가 정보 입력 */}
+                <AnimatePresence>
+                    {currentStep >= 3 && (
+                        <motion.div
+                            initial={{opacity: 0}}
+                            animate={{opacity: 1}}
+                            className="space-y-4"
+                        >
+                            <div className="flex items-center gap-2 mb-4">
+                                <UserCircleIcon className="w-6 h-6 text-green-500"/>
+                                <h2 className="text-xl font-semibold text-gray-800">추가 정보</h2>
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4 text-gray-700">
+                                {[
+                                    {id: 'username',
+                                        label: '사용자 ID',
+                                        icon: <IdentificationIcon className="w-5 h-5"/>,
+                                        placeholder: '사용자 id는 8~20자로 입력해 주세요'
+                                    },
+                                    {
+                                        id: 'password',
+                                        label: '비밀번호',
+                                        type: 'password',
+                                        icon: <LockClosedIcon className="w-5 h-5"/>,
+                                        placeholder: '비밀번호는 영문+숫자 조합 8자 이상'
+                                    },
+                                    {
+                                        id: 'checkPassword',
+                                        label: '비밀번호 확인',
+                                        type: 'password',
+                                        icon: <LockClosedIcon className="w-5 h-5"/>
+                                    },
+                                    {id: 'nickname', label: '닉네임', icon: <SparklesIcon className="w-5 h-5"/>},
+                                    {
+                                        id: 'phoneNumber',
+                                        label: '휴대폰 번호',
+                                        icon: <DevicePhoneMobileIcon className="w-5 h-5"/>
+                                    }
+                                ].map((field) => (
+                                    <motion.div
+                                        key={field.id}
+                                        initial={{opacity: 0}}
+                                        animate={{opacity: 1}}
+                                    >
+                                        <div className="flex items-center gap-2 mb-2 text-gray-600">
+                                            {field.icon}
+                                            <label>{field.label}</label>
+                                        </div>
+                                        <input
+                                            type={field.type || 'text'}
+                                            className={`w-full p-3 border-2 rounded-lg placeholder:text-gray-400 placeholder:text-sm ${
+                                                errors[field.id] ? 'border-red-500' : 'border-green-100'
+                                            }`}
+                                            placeholder={field.placeholder || ''}
+                                            onChange={(e) => {
+                                                setFormData({...formData, [field.id]: e.target.value});
+                                                if(field.id === 'username') {
+                                                    const isValid = e.target.value.length >=8 && e.target.value.length <=20;
+                                                    setErrors(prev => ({
+                                                        ...prev,
+                                                        username: isValid ? '' : '사용자 ID는 8~20자로 입력해 주세요'
+                                                    }));
+                                                }
+                                            }}
+                                        />
+                                        {errors.username && field.id === 'username' && (
+                                            <motion.div
+                                                initial={{ opacity: 0 }}
+                                                animate={{ opacity: 1 }}
+                                                className="text-red-500 text-sm mt-1"
+                                            >
+                                                {errors.username}
+                                            </motion.div>
+                                        )}
+                                    </motion.div>
+                                ))}
+                            </div>
+                            <button
+                                className={`w-full py-4 text-lg font-semibold text-white rounded-lg flex justify-center items-center transition-colors duration-200 bg-green-500 hover:bg-green-600`}
+                                type="submit"
+                                onClick={handleSubmit}
+                            >
+                                <div className="flex items-center gap-2">
+                                    <CheckCircleIcon className="h-5 w-5" />
+                                    <span>가입 완료하기</span>
+                                </div>
+                            </button>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+            </motion.form>
+        </div>
+    );
+}

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -1,9 +1,9 @@
-export default function Page() {
+import ClientPage from './ClientPage';
+
+export default function Main() {
     return (
-        <div className="flex justify-center items-center h-screen">
-            <h1 className="text-2xl font-bold text-gray-800">
-                예시 페이지입니다
-            </h1>
+        <div>
+            <ClientPage />
         </div>
     );
 }


### PR DESCRIPTION
## ✅ Check List
- 이전 소셜 회원 가입과 거의 유사합니다 (위치 검증하는 방식을 비동기 -> 동기로만 바꿨습니다)
- 주석 남겼고 회원 가입 이후 로그인 창으로 이동합니다
- 비밀번호 더블 체크한 후에 가입 가능, 위치가 다르면 가입 불가, 닉네임, 이메일, 아이디 등 중복이 있어도 가입되지 않습니다
- 이메일 인증 후 가입할 수 있습니다 (메일로 직접 코드 전송 됨)
- 다른 추가 내역들은 거의 애노테이션 추가나 import 삭제하거나 시큐리티 설정에 signup 추가 정도입니다

## 🔍 Test 
1. 로컬 서버 실행 
2. signup 페이지에서 회원가입 진행 (login 페이지에서 회원가입하기 누르거나 메인 페이지의 지금 가입하기를 눌러도 이동 가능함)
3. 성공 메시지 확인

<img width="804" alt="스크린샷 2025-03-10 오후 8 48 28" src="https://github.com/user-attachments/assets/fc64073c-27a6-468a-aaf6-9dd778f85446" />

- 토큰이 15분 타이머 걸어서 15분 안에 인증할 수 있도록 유도
- 오류 처리도 제대로 적용됩니다 
- 인증 확인 누른 후에 주소 작성 창으로 이동합니다

<img width="866" alt="스크린샷 2025-03-10 오후 8 48 52" src="https://github.com/user-attachments/assets/c850b298-86bf-4ece-ab89-a4bba0a442ec" />

- 주소 검색은 동일하게 카카오 우편번호 API 이용해서 받아올 수 있고, 해당 페이지에서도 geolation api 이용하기 때문에 브라우저 위치 정보 동의 팝업 뜹니다
- 주소를 등록하지 않으면 다음 단계로 이동 버튼 비활성화 됩니다 (추가 정보 기입 불가!)

<img width="781" alt="스크린샷 2025-03-10 오후 10 15 08" src="https://github.com/user-attachments/assets/035aa84f-760b-4557-9963-3f5c2bfe792d" />
<img width="859" alt="스크린샷 2025-03-10 오후 10 15 59" src="https://github.com/user-attachments/assets/c81be7bf-fddf-4741-8b70-5bb9528a9dce" />

- 주소가 반경 범위 내에 없을 시에 오류 적용됩니다

<img width="765" alt="스크린샷 2025-03-10 오후 10 05 06" src="https://github.com/user-attachments/assets/a7540e24-8c1f-4d8e-ad3a-6e69949d6350" />

- 추가 정보 입력할 수 있도록 했습니다
- 오류 처리는 이후 조금 더 명확하게 수정하도록 할게요!

<img width="501" alt="스크린샷 2025-03-10 오후 10 20 52" src="https://github.com/user-attachments/assets/cd203289-7fe1-4e09-8d93-4d9a1d56e9fc" />

- 가입 이후에 바로 로그인 페이지로 이동하고 로그인 제대로 이루어지고 토큰 연동되는 것까지 확인했습니다 👍 

## 🔗 Related Issues 
[[FEAT] 회원 가입 프론트 로직 구현 #7 ](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/7)

## 📝 Note (주의 사항) 
- 프론트에서 실시간 유효성 검사 로직 명확하게 변경 예정