### PR TITLE
[FEAT] 예약 상세 페이지 작성 + 스케줄 로직 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,6 +62,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.geolatte:geolatte-geom:1.9.0'
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.91.Final:osx-aarch_64'
+
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/deposit/entity/ReturnReason.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/deposit/entity/ReturnReason.java
@@ -5,5 +5,6 @@ public enum ReturnReason {
     NORMAL_COMPLETION,  // 정상 완료
     DAMAGE_REPORTED,    // 물건 훼손 발생
     ITEM_LOSS,          // 물건 분실 발생
-    REJECTED            // 요청 거절
+    REJECTED,           // 요청 거절
+    UNRESPONSIVE_RENTER // 대여자의 무응답
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/job/CompleteRentalJob.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/job/CompleteRentalJob.java
@@ -1,0 +1,46 @@
+package com.snackoverflow.toolgether.domain.job;
+
+import java.time.LocalDateTime;
+
+import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
+import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CompleteRentalJob implements Job{
+
+	@Autowired
+	private ReservationService reservationService;
+
+	@Override
+	public void execute(JobExecutionContext context) throws JobExecutionException {
+		JobDataMap jobDataMap = context.getMergedJobDataMap();
+		Object reservationIdObj = jobDataMap.get("reservationId");
+		Long reservationId = null;
+
+		if(reservationIdObj instanceof Long){
+			reservationId = (Long) reservationIdObj;
+		}
+
+		if (reservationId == null) {
+			log.error("reservationId is null in CompleteRentalJob!");
+			return;
+		}
+
+		log.info("CompleteRentalJob executed for reservationId: {}", reservationId);
+
+		// endTime이 현재 시간보다 이전인지 확인
+		LocalDateTime now = LocalDateTime.now();
+		Reservation reservation = reservationService.findReservationByIdOrThrow(reservationId);
+		if(reservation.getEndTime().isBefore(now)){
+			reservationService.completeRental(reservationId);
+		}
+	}
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/job/CompleteRentalJob.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/job/CompleteRentalJob.java
@@ -20,7 +20,7 @@ public class CompleteRentalJob implements Job{
 	private ReservationService reservationService;
 
 	@Override
-	public void execute(JobExecutionContext context) throws JobExecutionException {
+	public void execute(JobExecutionContext context) {
 		JobDataMap jobDataMap = context.getMergedJobDataMap();
 		Object reservationIdObj = jobDataMap.get("reservationId");
 		Long reservationId = null;

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/job/StartRentalJob.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/job/StartRentalJob.java
@@ -1,0 +1,50 @@
+package com.snackoverflow.toolgether.domain.job;
+
+import java.time.LocalDateTime;
+
+import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
+import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class StartRentalJob implements Job {
+
+	@Autowired
+	private ReservationService reservationService;
+
+	@Override
+	public void execute(JobExecutionContext context) {
+		JobDataMap jobDataMap = context.getMergedJobDataMap(); // 수정: getMergedJobDataMap() 사용
+		//Long reservationId = (Long) jobDataMap.get("reservationId");  // 타입 캐스팅 + null 체크
+		Object reservationIdObj = jobDataMap.get("reservationId");
+		Long reservationId = null;
+		if(reservationIdObj instanceof Long){
+			reservationId = (Long) reservationIdObj;
+		}
+
+
+		if (reservationId == null) {
+			log.error("reservationId is null in StartRentalJob!"); // null인 경우 로그 출력
+			return; // null이면 작업 중단
+		}
+
+		log.info("StartRentalJob executed for reservationId: {}", reservationId);
+		log.info("StartRentalJob: reservationService is null? {}", reservationService == null);
+
+		log.info("StartRentalJob executed for reservationId: {}", reservationId);
+		// startTime이 현재 시간보다 이전인지 확인하는 로직 추가
+		LocalDateTime now = LocalDateTime.now();
+		Reservation reservation = reservationService.findReservationByIdOrThrow(reservationId);
+
+		log.info("StartRentalJob - now: {}, startTime: {}, reservation: {}", now, reservation.getStartTime(), reservation);
+		if (reservation.getStartTime().isBefore(now)) {
+			reservationService.startRental(reservationId);
+		}
+	}
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
@@ -1,10 +1,7 @@
 package com.snackoverflow.toolgether.domain.reservation.controller;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.Set;
 
-import org.quartz.SchedulerException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,7 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.snackoverflow.toolgether.domain.reservation.dto.ReservationRequest;
 import com.snackoverflow.toolgether.domain.reservation.dto.ReservationResponse;
 import com.snackoverflow.toolgether.domain.reservation.entity.FailDue;
-import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
 import com.snackoverflow.toolgether.domain.reservation.service.ReservationService;
 import com.snackoverflow.toolgether.global.dto.RsData;
 

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
@@ -49,6 +49,13 @@ public class ReservationController {
 			"%d번 예약 거절 성공".formatted(id));
 	}
 
+	@PatchMapping("/{id}/cancel")
+	public RsData<Void> cancelReservation(@PathVariable Long id) {
+		reservationService.cancelReservation(id);
+		return new RsData<>("200-1",
+			"%d번 예약 취소 성공".formatted(id));
+	}
+
 	@PatchMapping("/{id}/start")
 	public RsData<Void> startRental(@PathVariable Long id) {
 		reservationService.startRental(id);

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/controller/ReservationController.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 
+import org.quartz.SchedulerException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/entity/Reservation.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/entity/Reservation.java
@@ -104,6 +104,13 @@ public class Reservation {
         }
         this.status = ReservationStatus.FAILED_RENTER_ISSUE;
     }
+
+    public void canceled(){
+        if(this.status != ReservationStatus.REQUESTED){
+            throw new IllegalStateException("요청 대기 상태에서만 취소 처리가 가능합니다.");
+        }
+        this.status = ReservationStatus.CANCELED;
+    }
     /* status 변경 함수 */
 
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/entity/ReservationStatus.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/entity/ReservationStatus.java
@@ -7,5 +7,6 @@ public enum ReservationStatus {
     REJECTED,            // 거절됨
     DONE,                // 정상 완료됨
     FAILED_OWNER_ISSUE,  // 소유자 문제로 실패함
-    FAILED_RENTER_ISSUE  // 대여자 문제로 실패함
+    FAILED_RENTER_ISSUE, // 대여자 문제로 실패함
+    CANCELED             // 취소됨
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
@@ -16,6 +16,4 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByOwnerId(Long ownerId);
 
     List<Reservation> findByPostId(Long postId);
-
-    List<Reservation> findByStatusAndStartTimeBefore(String status, LocalDateTime startTime);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/repository/ReservationRepository.java
@@ -4,6 +4,7 @@ import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -15,4 +16,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByOwnerId(Long ownerId);
 
     List<Reservation> findByPostId(Long postId);
+
+    List<Reservation> findByStatusAndStartTimeBefore(String status, LocalDateTime startTime);
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
@@ -3,15 +3,26 @@ package com.snackoverflow.toolgether.domain.reservation.service;
 import com.snackoverflow.toolgether.domain.reservation.entity.Reservation;
 import com.snackoverflow.toolgether.domain.reservation.entity.ReservationStatus;
 import com.snackoverflow.toolgether.domain.reservation.repository.ReservationRepository;
-import lombok.RequiredArgsConstructor;
-import java.net.URI;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
-import org.springframework.scheduling.annotation.Scheduled;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -27,14 +38,10 @@ import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.reservation.dto.ReservationRequest;
 import com.snackoverflow.toolgether.domain.reservation.dto.ReservationResponse;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
-import com.snackoverflow.toolgether.global.exception.ServiceException;
 import com.snackoverflow.toolgether.global.exception.custom.ErrorResponse;
 import com.snackoverflow.toolgether.global.exception.custom.CustomException;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Stream;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
@@ -42,6 +49,25 @@ public class ReservationService {
 	private final PostService postService;
 	private final UserService userService;
 	private final DepositHistoryService depositHistoryService;
+
+	// Quartz
+	private final Scheduler scheduler; // Quartz 스케줄러
+	private final JobDetail startRentalJobDetail; // Quartz JobDetail (시작)
+	private final JobDetail completeRentalJobDetail; // Quartz JobDetail (종료)
+
+	@PostConstruct
+	public void init() {
+		try {
+			if (!scheduler.isStarted()) { // 이미 시작되었는지 확인.  불필요한 재시작 방지.
+				scheduler.start();
+				log.info("Quartz Scheduler started.");
+			}
+		} catch (SchedulerException e) {
+			log.error("Failed to start Quartz Scheduler", e);
+			// throw new RuntimeException("Failed to start Quartz Scheduler", e); // 또는 다른 예외 처리
+			// 시작 실패 시, 애플리케이션을 중단시키는 것이 좋을 수도 있음.
+		}
+	}
 
 	// 예약 요청 (일정 충돌 방지 로직 필요)
 	@Transactional
@@ -89,8 +115,62 @@ public class ReservationService {
 	// 예약 승인
 	@Transactional
 	public void approveReservation(Long reservationId) {
-		Reservation reservation = findReservationByIdOrThrow(reservationId);
-		reservation.approve();
+		try {
+			Reservation reservation = findReservationByIdOrThrow(reservationId);
+			reservation.approve();
+
+			// Quartz Job 등록 (Start Rental)
+			JobDataMap startJobDataMap = new JobDataMap();
+			startJobDataMap.put("reservationId", reservationId); // 확인: reservationId가 null이 아닌지
+
+			// JobDetail에 JobDataMap 설정 (여기 수정)
+			JobDetail startJob = startRentalJobDetail.getJobBuilder()
+				.usingJobData(startJobDataMap) // usingJobData 사용
+				.withIdentity("startRentalJob-" + reservationId, "startRentalGroup")
+				.build();
+
+			Trigger startTrigger = TriggerBuilder.newTrigger()
+				.forJob(startJob) // 수정: startJob 사용
+				.withIdentity("startRentalTrigger-" + reservationId, "startRentalGroup") // 그룹 지정
+				.startAt(
+					Date.from(reservation.getStartTime().atZone(ZoneId.systemDefault()).toInstant())) // startTime에 실행
+				.withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
+				.build();
+
+			// Quartz Job 등록 (Complete Rental)
+			JobDataMap completeJobDataMap = new JobDataMap();
+			completeJobDataMap.put("reservationId", reservationId); //확인
+
+			// JobDetail에 JobDataMap 설정
+			JobDetail completeJob = completeRentalJobDetail.getJobBuilder()
+				.usingJobData(completeJobDataMap) // usingJobData 사용
+				.withIdentity("completeRentalJob-" + reservationId, "completeRentalGroup") // 더 구체적인 이름, 그룹
+				.build();
+
+			Trigger completeTrigger = TriggerBuilder.newTrigger()
+				.forJob(completeJob) // 수정: completeJob 사용
+				.withIdentity("completeRentalTrigger-" + reservationId, "completeRentalGroup") // 그룹 지정
+				.startAt(Date.from(reservation.getEndTime().atZone(ZoneId.systemDefault()).toInstant()))// endTime에 실행
+				.withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
+				.build();
+
+			System.out.println("대여 시작 시간 : " + startTrigger.getStartTime());
+			System.out.println("대여 종료 시간 : " + completeTrigger.getStartTime());
+
+			log.info("Scheduling StartRentalJob. Job Key: {}, Trigger Key: {}", startJob.getKey(), startTrigger.getKey()); // Job/Trigger 정보
+			log.info("Scheduling CompleteRentalJob. Job Key: {}, Trigger Key: {}", completeJob.getKey(), completeTrigger.getKey()); // Job/Trigger 정보
+
+			scheduler.scheduleJob(startJob, Set.of(startTrigger), true);
+			scheduler.scheduleJob(completeJob, Set.of(completeTrigger), true);
+
+			log.info("Job scheduled.  StartJob exists: {}, CompleteJob exists: {}",
+				scheduler.checkExists(startJob.getKey()), scheduler.checkExists(completeJob.getKey()));
+			log.info("Trigger scheduled. StartTrigger exists: {}, CompleteTrigger exists: {}",
+				scheduler.checkExists(startTrigger.getKey()), scheduler.checkExists(completeTrigger.getKey()));
+		}  catch (SchedulerException e) {
+			// SchedulerException을 RuntimeException으로 래핑하여 던짐
+			throw new RuntimeException("Failed to schedule start/complete rental job", e);
+		}
 	}
 
 	// 예약 거절
@@ -180,7 +260,7 @@ public class ReservationService {
 	}
 
 	// 예외 처리 포함 예약 조회 메서드
-	private Reservation findReservationByIdOrThrow(Long reservationId) {
+	public Reservation findReservationByIdOrThrow(Long reservationId) {
 		return reservationRepository.findById(reservationId)
 			.orElseThrow(() -> new CustomException(ErrorResponse.builder()
 				.title("예약 조회 실패")

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/reservation/service/ReservationService.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -122,6 +123,20 @@ public class ReservationService {
 		// 보증금 상태 변경 및 반환 사유 업데이트
 		DepositHistory depositHistory = depositHistoryService.findDepositHistoryByReservationId(reservationId);
 		depositHistoryService.updateDepositHistory(depositHistory.getId(), DepositStatus.RETURNED, ReturnReason.NORMAL_COMPLETION);
+
+		// 대여자 크레딧 업데이트
+		userService.updateUserCredit(reservation.getRenter().getId(), depositHistory.getAmount());
+	}
+
+	// 대여자 예약 취소
+	@Transactional
+	public void cancelReservation(Long reservationId) {
+		Reservation reservation = findReservationByIdOrThrow(reservationId);
+		reservation.canceled();
+
+		// 보증금 상태 변경 및 반환 사유 업데이트
+		DepositHistory depositHistory = depositHistoryService.findDepositHistoryByReservationId(reservationId);
+		depositHistoryService.updateDepositHistory(depositHistory.getId(), DepositStatus.RETURNED, ReturnReason.REJECTED);
 
 		// 대여자 크레딧 업데이트
 		userService.updateUserCredit(reservation.getRenter().getId(), depositHistory.getAmount());

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/QuartzConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/QuartzConfig.java
@@ -1,0 +1,52 @@
+package com.snackoverflow.toolgether.global.config;
+
+import org.quartz.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.snackoverflow.toolgether.domain.job.CompleteRentalJob;
+import com.snackoverflow.toolgether.domain.job.StartRentalJob;
+
+@Configuration
+public class QuartzConfig {
+
+	@Bean
+	public JobDetail startRentalJobDetail() {  //JobDetail 생성
+		return JobBuilder.newJob(StartRentalJob.class) // 어떤 Job을 실행시킬 것인가?
+			.withIdentity("startRentalJob") // Job 이름
+			.storeDurably() //DB에 저장되어 스케줄러가 다시 시작되어도 유지가 됨.
+			.build();
+	}
+
+	@Bean
+	public JobDetail completeRentalJobDetail() { // JobDetail
+		return JobBuilder.newJob(CompleteRentalJob.class) // 어떤 Job을 실행시킬 것인가?
+			.withIdentity("completeRentalJob") // Job 이름
+			.storeDurably()  //DB에 저장
+			.build();
+	}
+
+
+	// startTime에 Trigger
+	@Bean
+	public Trigger startRentalTrigger(JobDetail startRentalJobDetail) { // Trigger 생성
+		//SimpleScheduleBuilder는 특정 시간에 한번만 실행하는 Trigger
+		return TriggerBuilder.newTrigger()
+			.forJob(startRentalJobDetail)  // 어떤 JobDetail에 Trigger를 걸 것인가?
+			.withIdentity("startRentalTrigger") // 트리거 이름
+			// .startAt()  // 언제 실행할 것인가? -> 서비스에서 처리
+			.withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow()) // 놓친 스케줄은 즉시 실행
+			.build();
+	}
+
+	// endTime에 Trigger
+	@Bean
+	public Trigger completeRentalTrigger(JobDetail completeRentalJobDetail) { // Trigger
+		return TriggerBuilder.newTrigger()
+			.forJob(completeRentalJobDetail) // 어떤 JobDetail에 Trigger를 걸 것인가?
+			.withIdentity("completeRentalTrigger") // 트리거 이름
+			//.startAt() // 서비스에서 처리
+			.withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
+			.build();
+	}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -71,6 +71,11 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
 
+  quartz:
+    job-store-type: jdbc
+    jdbc:
+      initialize-schema: always # DB 초기화. create-drop, always, embedded, never 중 하나. create/always는 개발환경에서만.
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/frontend/app/mypage/reservationDetail/[id]/ClientPage.tsx
+++ b/frontend/app/mypage/reservationDetail/[id]/ClientPage.tsx
@@ -610,6 +610,12 @@ function DoneStatus({
   reservation: Reservation;
   deposit: Deposit;
 }) {
+  const router = useRouter(); // useRouter 훅 사용
+
+  const goToReviewPage = () => {
+    // 임시 URL.  나중에 실제 리뷰 페이지 URL로 변경해야 함.
+    router.push(`/review/${reservation.id}`);
+  };
   return (
     <div className="flex flex-col items-center justify-center w-[70%] h-150 border rounded-lg shadow-md p-6 bg-gray-200">
       <p className="text-5xl font-bold text-gray-600 mb-4">🏁</p>
@@ -625,6 +631,12 @@ function DoneStatus({
         대여료 {reservation.amount - deposit.amount}₩ + 보증금 {deposit.amount}₩
       </p>
       <p className="text-lg mb-2 font-bold">합계 {reservation.amount}₩</p>
+      <button
+        className="mt-4 bg-green-500 hover:bg-yellow-600 text-white font-bold py-2 px-4 rounded"
+        onClick={goToReviewPage}
+      >
+        유저 리뷰하기
+      </button>
     </div>
   );
 }

--- a/frontend/app/mypage/reservationDetail/[id]/ClientPage.tsx
+++ b/frontend/app/mypage/reservationDetail/[id]/ClientPage.tsx
@@ -1,7 +1,7 @@
 // app/reservations/complete/page.jsx
 "use client";
 
-import { c } from "framer-motion/dist/types.d-6pKw1mTI";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 interface Reservation {
@@ -59,54 +59,92 @@ function RequestedStatus({
   reservation,
   deposit,
   me,
+  renter,
 }: {
   reservation: Reservation;
   deposit: Deposit;
   me: me;
+  renter: me;
 }) {
-  const [renter, setRenter] = useState<Me | null>(null);
   const [showModal, setShowModal] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (me.id === reservation.ownerId) {
-      fetchRenterInfo(reservation.renterId);
-    }
-  }, [me.id, reservation.ownerId, reservation.renterId]);
-
-  const fetchRenterInfo = async (renterId: number) => {
-    try {
-      const response = await fetch(
-        `http://localhost:8080/api/v1/users/${renterId}`
-      );
-      if (response.ok) {
-        const data = await response.json();
-        console.log("Renter Info:", data);
-        setRenter(data.data);
-      } else {
-        console.error("Failed to fetch renter info");
-      }
-    } catch (error) {
-      console.error("Error fetching renter info:", error);
-    }
-  };
+  const [showConfirmModal, setShowConfirmModal] = useState(false); // 추가: 승인/거절 확인 모달
+  const [modalMessage, setModalMessage] = useState(""); // 추가: 모달 메시지
+  const [actionType, setActionType] = useState<"approve" | "reject" | null>(
+    null
+  );
+  const [rejectionReason, setRejectionReason] = useState("");
 
   const openModal = () => setShowModal(true);
   const closeModal = () => setShowModal(false);
 
   const handleApproval = () => {
-    // 승인 로직
-    console.log("승인");
+    setActionType("approve");
+    setModalMessage("정말 승인하시겠습니까?");
+    setShowConfirmModal(true);
   };
 
   const handleRejection = () => {
-    // 거절 로직
-    console.log("거절");
+    setActionType("reject");
+    setModalMessage("정말 거절하시겠습니까?");
+    setShowConfirmModal(true);
   };
 
   const handleCancel = () => {
     // 예약 취소 로직
     console.log("예약 취소");
   };
+
+  // 승인 or 거절 API
+  const confirmAction = async () => {
+    setShowConfirmModal(false); // 확인 모달 닫기
+    if (actionType === "approve") {
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/v1/reservations/${reservation.id}/approve`,
+          {
+            method: "PATCH",
+          }
+        );
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          const errorData = await response.json();
+          alert(`승인 실패: ${errorData.message || "서버 오류"}`);
+        }
+      } catch (error) {
+        alert("승인 처리 중 오류 발생");
+        console.error(error);
+      }
+    } else if (actionType === "reject") {
+      // 거절 로직
+      if (!rejectionReason.trim()) {
+        alert("거절 사유를 입력해주세요.");
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `http://localhost:8080/api/v1/reservations/${
+            reservation.id
+          }/reject?reason=${encodeURIComponent(rejectionReason)}`,
+          {
+            method: "PATCH",
+          }
+        );
+        if (response.ok) {
+          setModalMessage("거절이 완료되었습니다.");
+          setShowModal(true);
+        } else {
+          const errorData = await response.json();
+          alert(`거절 실패: ${errorData.message || "서버 오류"}`);
+        }
+      } catch (error) {
+        alert("거절 처리 중 오류 발생");
+        console.error(error);
+      }
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center w-[70%] h-150 border rounded-lg shadow-md p-6 bg-gray-100">
       <p className="text-5xl font-bold text-blue-600 mb-4">📖</p>
@@ -162,6 +200,37 @@ function RequestedStatus({
           예약 취소
         </button>
       ) : null}
+      {/* 확인 모달 */}
+      {showConfirmModal && (
+        <div className="fixed inset-0 flex justify-center items-center bg-transparent backdrop-filter backdrop-blur-lg">
+          <div className="bg-white p-4 rounded-lg">
+            <p>{modalMessage}</p>
+            {actionType === "reject" && (
+              <div>
+                <input
+                  type="text"
+                  value={rejectionReason}
+                  onChange={(e) => setRejectionReason(e.target.value)}
+                  placeholder="거절 사유를 입력하세요"
+                  className="border p-2 rounded w-full my-2"
+                />
+              </div>
+            )}
+            <button
+              className="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-[50%]"
+              onClick={confirmAction}
+            >
+              예
+            </button>
+            <button
+              className="mt-4 bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded w-[50%]"
+              onClick={() => setShowConfirmModal(false)}
+            >
+              아니오
+            </button>
+          </div>
+        </div>
+      )}
       {showModal && renter && (
         <div className="fixed inset-0 flex justify-center items-center bg-transparent backdrop-filter backdrop-blur-lg">
           <div className="relative p-8 bg-white w-1/2 rounded-lg">
@@ -186,10 +255,22 @@ function RequestedStatus({
 function ApprovedStatus({
   reservation,
   deposit,
+  me,
+  owner,
 }: {
   reservation: Reservation;
   deposit: Deposit;
+  me: me;
+  owner: me;
 }) {
+  const [showModal, setShowModal] = useState<boolean>(false);
+
+  if (!owner) {
+    return <div>Loading...</div>; // 또는 return null;
+  }
+
+  const openModal = () => setShowModal(true);
+  const closeModal = () => setShowModal(false);
   return (
     <div className="flex flex-col items-center justify-center w-[70%] h-150 border rounded-lg shadow-md p-6 bg-green-200">
       <p className="text-5xl font-bold text-green-600 mb-4">✅</p>
@@ -205,6 +286,40 @@ function ApprovedStatus({
         대여료 {reservation.amount - deposit.amount}₩ + 보증금 {deposit.amount}₩
       </p>
       <p className="text-lg mb-2 font-bold">합계 {reservation.amount}₩</p>
+      {me.id === reservation.renterId ? (
+        <button
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          onClick={openModal}
+        >
+          소유자 {owner.nickname}님의 상세 정보 보기
+        </button>
+      ) : null}
+      {showModal && owner && (
+        <div className="fixed inset-0 flex justify-center items-center text-center bg-transparent backdrop-filter backdrop-blur-lg">
+          <div className="relative p-8 bg-white w-1/2 rounded-lg">
+            <h2 className="text-2xl font-bold mb-4">
+              {owner.nickname}님의 정보
+            </h2>
+            <p>이메일: {owner.email}</p>
+            <p>
+              <b>{owner.nickname}</b> 님의 점수는 {owner.score}점입니다!
+            </p>
+            <br />
+            <p className="font-bold">상세 주소</p>
+            <p>{owner.address.mainAddress}</p>
+            <p>{owner.address.detailAddress}</p>
+            <br />
+            <p className="font-bold">전화번호</p>
+            <p>{owner.phoneNumber}</p>
+            <button
+              className="mt-4 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded"
+              onClick={closeModal}
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -216,6 +331,65 @@ function InProgressStatus({
   reservation: Reservation;
   deposit: Deposit;
 }) {
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const [selectedIssue, setSelectedIssue] = useState<{
+    value: string;
+    label: string;
+    issueType: "owner" | "renter";
+  } | null>(null); // 선택된 이슈
+
+  // 선택 가능한 사유 목록 (issueType 추가)
+  const issueOptions = [
+    { value: "DAMAGE_REPORTED", label: "물건 훼손", issueType: "renter" },
+    { value: "ITEM_LOSS", label: "물건 분실", issueType: "renter" },
+    {
+      value: "UNRESPONSIVE_RENTER",
+      label: "대여자의 무응답",
+      issueType: "owner",
+    }, // owner
+  ];
+
+  const handleIssue = () => {
+    setModalMessage("문제가 발생했습니까?");
+    setShowConfirmModal(true);
+  };
+
+  const confirmAction = async () => {
+    setShowConfirmModal(false);
+
+    if (!selectedIssue) {
+      alert("이유를 선택해주세요.");
+      return;
+    }
+    let apiUrl = "";
+    if (selectedIssue.issueType === "owner") {
+      apiUrl = `http://localhost:8080/api/v1/reservations/${
+        reservation.id
+      }/ownerIssue?reason=${encodeURIComponent(selectedIssue.value)}`;
+    } else if (selectedIssue.issueType === "renter") {
+      apiUrl = `http://localhost:8080/api/v1/reservations/${
+        reservation.id
+      }/renterIssue?reason=${encodeURIComponent(selectedIssue.value)}`;
+    }
+
+    try {
+      const response = await fetch(apiUrl, {
+        method: "PATCH",
+      });
+
+      if (response.ok) {
+        window.location.reload();
+      } else {
+        const errorData = await response.json();
+        alert(`문제 해결 요청 실패: ${errorData.message || "서버 오류"}`);
+      }
+    } catch (error) {
+      alert("문제 해결 요청 중 오류 발생");
+      console.error(error);
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center w-[70%] h-150 border rounded-lg shadow-md p-6 bg-yellow-200">
       <p className="text-5xl font-bold text-yellow-600 mb-4">⏳</p>
@@ -228,7 +402,57 @@ function InProgressStatus({
       <p className="text-lg mb-8">
         대여료 {reservation.amount - deposit.amount}₩ + 보증금 {deposit.amount}₩
       </p>
-      <p className="text-lg mb-2 font-bold">합계 {reservation.amount}₩</p>
+      <p className="text-lg mb-2 font-bold">대여 중 문제가 발생하셨나요?</p>
+      <button
+        className="mt-4 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded"
+        onClick={handleIssue}
+      >
+        문제 보고하기
+      </button>
+
+      {/* 확인 모달 */}
+      {showConfirmModal && (
+        <div className="fixed inset-0 flex justify-center items-center bg-transparent backdrop-filter backdrop-blur-lg">
+          <div className="bg-white w-[50%] p-4 rounded-lg">
+            <p>{modalMessage}</p>
+            {/* 드롭다운 */}
+            <div>
+              <select
+                value={selectedIssue ? selectedIssue.value : ""} // value 수정
+                onChange={(e) => {
+                  const selectedValue = e.target.value;
+                  const option = issueOptions.find(
+                    (opt) => opt.value === selectedValue
+                  ); // find로 option 찾기
+                  setSelectedIssue(option || null); // 찾은 option으로 selectedIssue 설정
+                }}
+                className="border p-2 rounded w-full my-2"
+              >
+                <option value="">사유 선택</option>
+                {issueOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex justify-center">
+              <button
+                className="mt-4 bg-blue-500 hover:bg-blue-700 text-white mr-10 font-bold py-2 px-4 rounded w-[30%]"
+                onClick={confirmAction}
+              >
+                예
+              </button>
+              <button
+                className="mt-4 bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded w-[30%]"
+                onClick={() => setShowConfirmModal(false)}
+              >
+                아니오
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -236,17 +460,39 @@ function InProgressStatus({
 function RejectedStatus({
   reservation,
   deposit,
+  me,
+  renter,
 }: {
   reservation: Reservation;
   deposit: Deposit;
+  me: me;
+  renter: me;
 }) {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const openModal = () => setShowModal(true);
+  const closeModal = () => setShowModal(false);
   return (
     <div className="flex flex-col items-center justify-center w-[70%] h-150 border rounded-lg shadow-md p-6 bg-red-200">
       <p className="text-5xl font-bold text-red-600 mb-4">❌</p>
-      <p className="text-4xl font-bold text-red-600 mb-4">
-        예약이 거절되었습니다
-      </p>
-      <p className="text-lg mb-2">다른 예약을 시도해주세요.</p>
+      {me.id === reservation.ownerId && renter ? (
+        // 호스트인 경우 대여자 이름 표시
+
+        <p className="text-4xl mb-2 font-bold">
+          <span className="text-blue-600 cursor-pointer" onClick={openModal}>
+            {renter.nickname}
+          </span>
+          님의 예약을 취소하셨습니다.
+        </p>
+      ) : me.id === reservation.renterId ? (
+        // 세입자인 경우 예약 확인 메시지 표시
+        <>
+          <p className="text-4xl font-bold text-green-600 mb-4">
+            예약이 취소되었습니다
+          </p>
+          <p className="text-lg mb-2">다른 예약을 시도해주세요.</p>
+        </>
+      ) : null}
+
       <p className="text-lg mb-2 font-bold">사유</p>
       <p className="text-lg mb-2 font-bold">{reservation.rejectionReason}</p>
       <p className="text-lg mb-2">
@@ -256,9 +502,82 @@ function RejectedStatus({
         대여료 {reservation.amount - deposit.amount}₩ + 보증금 {deposit.amount}₩
       </p>
       <p className="text-lg mb-2 font-bold">합계 {reservation.amount}₩</p>
-      <button className="text-lg bg-red-500 text-white px-4 py-2 rounded-lg">
-        다시 예약하기
-      </button>
+      {me.id === reservation.renterId ? (
+        <button className="text-lg bg-red-500 text-white px-4 py-2 rounded-lg">
+          다시 예약하기
+        </button>
+      ) : null}
+      {showModal && renter && (
+        <div className="fixed inset-0 flex justify-center items-center bg-transparent backdrop-filter backdrop-blur-lg">
+          <div className="relative p-8 bg-white w-1/2 rounded-lg">
+            <h2 className="text-2xl font-bold mb-4">{renter.nickname} 정보</h2>
+            <p>이메일: {renter.email}</p>
+            <p>
+              <b>{renter.nickname}</b> 님의 점수는 {renter.score}점입니다!
+            </p>
+            <button
+              className="mt-4 bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded"
+              onClick={closeModal}
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FailedStatus({
+  reservation,
+  deposit,
+  me,
+  renter,
+  owner,
+  reason,
+}: {
+  reservation: Reservation;
+  deposit: Deposit;
+  me: me;
+  renter: me | null;
+  owner: me | null;
+  reason: string; // 실패 사유 (API에서 전달받음)
+}) {
+  const issueOptions = [
+    { value: "DAMAGE_REPORTED", label: "물건 훼손", issueType: "renter" },
+    { value: "ITEM_LOSS", label: "물건 분실", issueType: "renter" },
+    {
+      value: "UNRESPONSIVE_RENTER",
+      label: "대여자의 무응답",
+      issueType: "owner",
+    }, // owner
+  ];
+
+  const reasonLabel = issueOptions.find(
+    (option) => option.value === deposit.returnReason
+  )?.label;
+  return (
+    <div className="flex flex-col items-center justify-center w-[70%] h-150 border rounded-lg shadow-md p-6 bg-red-100">
+      <p className="text-5xl font-bold text-red-600 mb-4">⚠️</p>
+      <p className="text-4xl font-bold text-red-600 mb-4">
+        {/* 예약 실패 사유에 따라 다른 메시지 표시 */}
+        {reservation.status === "FAILED_OWNER_ISSUE"
+          ? "소유자 문제로 예약이 실패했습니다."
+          : reservation.status === "FAILED_RENTER_ISSUE"
+          ? "대여자 문제로 예약이 실패했습니다."
+          : "예약 실패"}
+      </p>
+      <p className="text-lg mb-2 font-bold">
+        사유: {reasonLabel || deposit.returnReason}
+      </p>
+
+      <p className="text-lg mb-2">
+        {formatDate(reservation.startTime)} ~ {formatDate(reservation.endTime)}
+      </p>
+      <p className="text-lg mb-8">
+        대여료 {reservation.amount - deposit.amount}₩ + 보증금 {deposit.amount}₩
+      </p>
+      <p className="text-lg mb-2 font-bold">합계 {reservation.amount}₩</p>
     </div>
   );
 }
@@ -294,57 +613,117 @@ export default function ClientPage({
   deposit,
   me,
 }: {
-  reservation: {
-    id: number;
-    status: string;
-    postId: number;
-    startTime: string;
-    endTime: string;
-    amount: number;
-    rejectionReason: string;
-    ownerId: number;
-    renterId: number;
-  };
-  deposit: {
-    id: number;
-    status: string;
-    amount: number;
-    returnReason: string;
-  };
-  me: {
-    id: number;
-    nickname: string;
-    username: string;
-    profileImage: string;
-    email: string;
-    phoneNumber: string;
-    address: {
-      mainAddress: string;
-      detailAddress: string;
-      zipcode: string;
-    };
-    createdAt: string;
-    score: number;
-    credit: number;
-  };
+  reservation: Reservation;
+  deposit: Deposit;
+  me: me;
 }) {
+  const [renter, setRenter] = useState<me | null>(null);
+  const [owner, setOwner] = useState<me | null>(null);
+
+  useEffect(() => {
+    console.log("useEffect");
+    fetchRenterInfo(reservation.renterId);
+    fetchOwnerInfo(reservation.ownerId);
+  }, []);
+
+  const fetchRenterInfo = async (renterId: number) => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v1/users/${renterId}`
+      );
+      if (response.ok) {
+        const data = await response.json();
+        console.log("Renter Info:", data.data);
+        setRenter(data.data);
+      } else {
+        console.error("Failed to fetch renter info");
+      }
+    } catch (error) {
+      console.error("Error fetching renter info:", error);
+    }
+  };
+
+  const fetchOwnerInfo = async (ownerId: number) => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/v1/users/${ownerId}`
+      );
+      if (response.ok) {
+        const data = await response.json();
+        console.log("Owner Info:", data);
+        setOwner(data.data);
+      } else {
+        console.error("Failed to fetch renter info");
+      }
+    } catch (error) {
+      console.error("Error fetching renter info:", error);
+    }
+  };
+
+  const router = useRouter();
+
+  const goToMyPage = () => {
+    router.push("/mypage"); // /mypage 경로로 이동
+  };
+
   return (
-    <div className="flex justify-center items-center min-h-screen">
+    <div className="flex flex-col justify-center items-center min-h-screen">
       {reservation.status === "REQUESTED" && (
-        <RequestedStatus reservation={reservation} deposit={deposit} me={me} />
+        <RequestedStatus
+          reservation={reservation}
+          deposit={deposit}
+          me={me}
+          renter={renter}
+        />
       )}
       {reservation.status === "APPROVED" && (
-        <ApprovedStatus reservation={reservation} deposit={deposit} />
+        <ApprovedStatus
+          reservation={reservation}
+          deposit={deposit}
+          me={me}
+          owner={owner}
+        />
       )}
       {reservation.status === "IN_PROGRESS" && (
         <InProgressStatus reservation={reservation} deposit={deposit} />
       )}
       {reservation.status === "REJECTED" && (
-        <RejectedStatus reservation={reservation} deposit={deposit} />
+        <RejectedStatus
+          reservation={reservation}
+          deposit={deposit}
+          me={me}
+          renter={renter}
+        />
       )}
       {reservation.status === "DONE" && (
         <DoneStatus reservation={reservation} deposit={deposit} />
       )}
+      {reservation.status === "FAILED_OWNER_ISSUE" && (
+        <FailedStatus
+          reservation={reservation}
+          deposit={deposit}
+          me={me}
+          renter={renter}
+          owner={owner}
+          reason="OWNER_ISSUE"
+        />
+      )}
+      {reservation.status === "FAILED_RENTER_ISSUE" && (
+        <FailedStatus
+          reservation={reservation}
+          deposit={deposit}
+          me={me}
+          renter={renter}
+          owner={owner}
+          reason="RENTER_ISSUE"
+        />
+      )}
+      <button
+        className="mt-4 bg-green-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        onClick={goToMyPage} // 버튼 클릭 시 goToMyPage 함수 호출
+      >
+        마이페이지로 이동
+      </button>
     </div>
   );
 }

--- a/frontend/app/mypage/reservationDetail/[id]/page.tsx
+++ b/frontend/app/mypage/reservationDetail/[id]/page.tsx
@@ -99,7 +99,7 @@ export default async function Page({
     <ClientPage
       reservation={reservationData}
       deposit={depositData}
-      me={mockUpOwner.data}
+      me={mockUpRenter.data}
     />
   );
 }


### PR DESCRIPTION
## ✅ Check List
- [x] 예약 상세 보기 프론트 엔드 작성
- [x] User가 소유자 or 대여자인지에 따라 다른 폼 출력
- [x] 예약 상태 변경 API 연결
- [x] 예약 승인 -> 대여 중 -> 대여 완료 과정을 자동화하는 스케줄 로직

## 🔍 Test 
![image](https://github.com/user-attachments/assets/cbd16a4c-aecc-4fa9-a71e-d3912b2d40e9)
![image](https://github.com/user-attachments/assets/34e76765-246f-437b-a8e2-b22e75cd68db)
![image](https://github.com/user-attachments/assets/3f06e617-8daa-4438-9f21-2f84479ce294)
![image](https://github.com/user-attachments/assets/920a3549-7318-4a7a-8cc7-fb8d530f7e7b)
![image](https://github.com/user-attachments/assets/0bb15ace-13bc-47fc-a791-1d31e27ec71a)
![image](https://github.com/user-attachments/assets/d91d45fd-4069-45b8-a81f-5c80b6ce1b3f)
![image](https://github.com/user-attachments/assets/6937d9f0-c5c1-40ec-a1ce-18f8fec47667)
![image](https://github.com/user-attachments/assets/1f9061d4-bcbc-461d-9970-1246e6af086e)


  1. 예약 요청 페이지
  2. 거절 시 거절 사유 입력
  3. 거절 페이지
  4. 승인 페이지
  5. 예약 확정 페이지 -> 스케줄러로 시간이 되면 자동 대여중 상태 전환
  6. 대여 중 페이지 -> 문제 발생 시 사유 작성 가능
  7. 이용 완료 페이지

## 🔗 Related Issues 
[[FEAT] 예약 상세 페이지 작성](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/30)

## 📝 Note (주의 사항) 
대여자 or 소유자에 따라 다른 UI 제공