### PR TITLE
✨ feat: 리프레시 토큰으로 액세스 토큰 재발급 issue: #51

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -65,6 +65,10 @@ dependencies {
 	implementation 'org.geolatte:geolatte-geom:1.9.0'
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.91.Final:osx-aarch_64'
 
+	// Google
+	implementation 'com.google.api-client:google-api-client:2.7.2'
+	implementation 'com.google.http-client:google-http-client-gson:1.43.3'
+
 	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserOauthController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserOauthController.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -28,8 +29,6 @@ import java.util.Map;
 public class UserOauthController {
 
     private final OauthService oauthService;
-    private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
 
     @PostMapping("/login/oauth2/code/google")
     public RsData<?> handleAuthCode(@RequestBody Map<String, String> request,
@@ -44,8 +43,8 @@ public class UserOauthController {
             // 토큰 가져오기
             Map<String, String> tokens = oauthService.getTokens(authCode);
 
-            // 리프레시 토큰을 쿠키에 저장
-            setRefreshTokenCookie(response, tokens);
+            // 구글에서 발행한 리프레시 토큰을 쿠키에 저장
+            setRefreshTokenCookie(response, tokens.get("refresh_token"));
 
             // 액세스 토큰에서 유저 정보 추출
             Map<String, Object> userInfo = oauthService.getUserInfo(tokens.get("access_token"));
@@ -54,25 +53,24 @@ public class UserOauthController {
 
             /**
              * 소셜 로그인 사용자 존재 여부 체크
-             * 존재하면 기존 로그인 진행
+             * 존재하면 기존 로그인 진행 -> 액세스 토큰
              * 존재하지 않는 회원이라면 추가 정보 기입으로 이동
              */
             if (oauthService.existsUser(email)) {
-                User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
-                setJwtToken(response, user.getId());
+                // 액세스 토큰을 응답 바디에 저장
                 return new RsData<>(
                         "200-1",
                         "기존 사용자 로그인 성공",
-                        null
+                        Map.of("access_token", tokens.get("access_token"))
                 );
             }
 
             User socialUser = oauthService.createSocialUser(userInfo);
-            setJwtToken(response, socialUser.getId());
             return new RsData<>(
                     "201-1",
                     "신규 회원 가입 완료 - 추가 정보 입력 필요",
-                    Map.of("additionalInfoRequired", socialUser.isAdditionalInfoRequired())
+                    Map.of("additionalInfoRequired", socialUser.isAdditionalInfoRequired(),
+                            "access_token", tokens.get("access_token"))
             );
         } catch (Exception e) {
             throw new RuntimeException("액세스 토큰 추출 중 오류 발생!");
@@ -82,8 +80,7 @@ public class UserOauthController {
     @PatchMapping("/oauth/users/additional-info")
     public Mono<RsData<Object>> updateAdditionalInfo(
             @Validated @RequestBody AdditionalInfoRequest request,
-            @Login CustomUserDetails userDetails,
-            HttpServletResponse response) {
+            @Login CustomUserDetails userDetails) {
         return oauthService.updateAdditionalInfo(userDetails.getEmail(), request)
                 .map(isLocationValid -> {
                     if (Boolean.FALSE.equals(isLocationValid)) {
@@ -93,7 +90,8 @@ public class UserOauthController {
                                 "위치 정보가 허용 범위를 벗어났습니다.",
                                 null);
                     }
-                    setJwtToken(response, userDetails.getUserId());
+
+                    // 액세스 토큰 생성 후 바디로 전송
                     return new RsData<>(
                             "201-2",
                             "추가 정보가 등록되었습니다.",
@@ -101,19 +99,30 @@ public class UserOauthController {
                 });
     }
 
-    // 토큰 이메일 기반 -> userId 기반으로 변경
-    private void setJwtToken(HttpServletResponse response, Long userId) {
-        Map<String, Object> claims = new HashMap<>();
-        claims.put("userId", userId);
-        String token = jwtUtil.createToken(claims);
-        jwtUtil.setJwtInCookie(token, response);
+    @PostMapping("/oauth/token/refresh")
+    public RsData<?> refreshAccessToken(@CookieValue("refresh_token") String refreshToken) {
+        try {
+            String newAccessToken = oauthService.refreshAccessToken(refreshToken);
+            return new RsData(
+                    "201-1",
+                    "토큰 재발행 완료",
+                    Map.of("access_token", newAccessToken)
+            );
+        } catch (Exception e) {
+            return new RsData<>(
+                    "401-1",
+                    "리프레시 토큰이 유효하지 않습니다.",
+                    null
+            );
+        }
     }
 
-    private void setRefreshTokenCookie(HttpServletResponse response, Map<String, String> tokens) {
-        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", tokens.get("refresh_token"))
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
                 .httpOnly(true)
-                .secure(true)
-                .maxAge(Duration.ofDays(30).toSeconds())
+                .secure(true) // HTTPS에서만 전송
+                .path("/") // 특정 경로로 제한
+                .maxAge(Duration.ofDays(30).toSeconds()) // 30일
                 .sameSite("None")
                 .build();
 

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/OauthService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/OauthService.java
@@ -1,5 +1,9 @@
 package com.snackoverflow.toolgether.domain.user.service;
 
+import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.googleapis.auth.oauth2.GoogleRefreshTokenRequest;
 import com.snackoverflow.toolgether.domain.user.dto.KakaoGeoResponse;
 import com.snackoverflow.toolgether.domain.user.dto.request.AdditionalInfoRequest;
 import com.snackoverflow.toolgether.domain.user.entity.Address;
@@ -20,6 +24,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
 import java.util.Map;
 
 @Slf4j
@@ -194,5 +199,21 @@ public class OauthService {
                                 return Mono.just(false); // 실패 시 false 반환
                             });
                 });
+    }
+
+    // 리프레시 토큰으로 액세스 토큰 재발급
+    public String refreshAccessToken(String refreshToken) throws IOException {
+        log.info("토큰 재발행 로직 시작");
+        GoogleTokenResponse tokenResponse = new GoogleRefreshTokenRequest(
+                new NetHttpTransport(),
+                GsonFactory.getDefaultInstance(),
+                refreshToken,
+                clientId,
+                clientSecret
+        ).execute();
+
+        // 새로 발급된 액세스 토큰
+        log.info("새로 발급된 액세스 토큰 = {}", tokenResponse.getAccessToken());
+        return tokenResponse.getAccessToken();
     }
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.snackoverflow.toolgether.global.config;
 
+import com.snackoverflow.toolgether.global.filter.GoogleAccessTokenFilter;
 import com.snackoverflow.toolgether.global.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -25,6 +26,7 @@ import java.util.List;
 class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final GoogleAccessTokenFilter googleAccessTokenFilter;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,10 +34,16 @@ class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(authorize ->
                         authorize
-                                .requestMatchers("/login/oauth2/code/google", "/api/v1/users/login", "/h2-console/**", "/oauth/users/additional-info", "/api/v1/users/**").permitAll() // 특정 경로만 허용
+                                .requestMatchers("/login/oauth2/code/google",
+                                        "/api/v1/users/login",
+                                        "/h2-console/**",
+                                        "/oauth/users/additional-info",
+                                        "/oauth/token/refresh",
+                                        "/api/v1/users/**").permitAll() // 특정 경로만 허용
                                 .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(googleAccessTokenFilter, JwtAuthenticationFilter.class)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/filter/GoogleAccessTokenFilter.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/filter/GoogleAccessTokenFilter.java
@@ -1,0 +1,69 @@
+package com.snackoverflow.toolgether.global.filter;
+
+import com.snackoverflow.toolgether.domain.user.entity.User;
+import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
+import com.snackoverflow.toolgether.domain.user.service.OauthService;
+import com.snackoverflow.toolgether.global.exception.custom.user.UserNotFoundException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+// 헤더 기반 OAuth2 액세스 토큰 처리를 담당
+public class GoogleAccessTokenFilter extends OncePerRequestFilter {
+
+    private final OauthService oauthService;
+    private final UserRepository userRepository;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        log.info("GoogleAccessTokenFilter 실행됨");
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String accessToken = authHeader.substring(7);// "Bearer " 제거
+            log.info("accessToken = {}", accessToken);
+            try {
+                Map<String, Object> userInfo = oauthService.getUserInfo(accessToken);
+                String email = (String) userInfo.get("email");
+                User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+
+                CustomUserDetails customUserDetails = new CustomUserDetails(user.getUsername(), email, user.getId());
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        customUserDetails, null, Collections.emptyList());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info("authentication = {}", authentication);
+                filterChain.doFilter(request, response);
+            } catch (RuntimeException e) {
+                log.error("OAuth2 Access Token 처리 중 오류 발생: {}", e.getMessage());
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("액세스 토큰이 유효하지 않습니다.");
+            }
+        }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String authHeader = request.getHeader("Authorization");
+        return authHeader == null || !authHeader.startsWith("Bearer "); // Authorization 헤더가 없는 경우 제외
+    }
+}

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/filter/JwtAuthenticationFilter.java
@@ -64,8 +64,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
             filterChain.doFilter(request, response);
-        } catch (JwtException e) {
-            // 토큰이 없어도 게시물은 조회할 수 있도록
+        } catch (UserNotFoundException | JwtException e) {
+            log.error("오류 발생: {}", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 Unauthorized 반환
+            response.getWriter().write("Unauthorized: " + e.getMessage());
             filterChain.doFilter(request, response);
         }
     }
@@ -73,6 +75,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String requestURI = request.getRequestURI();
-        return requestURI.startsWith("/h2-console") || requestURI.matches(".*\\.(css|js|gif|png|jpg|ico)$");
+        return requestURI.startsWith("/h2-console") ||
+                requestURI.startsWith("/login/oauth2/code/google") ||
+                requestURI.matches(".*\\.(css|js|gif|png|jpg|ico)$");
     }
 }

--- a/frontend/app/additional-info/ClientPage.tsx
+++ b/frontend/app/additional-info/ClientPage.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { PhoneIcon, MapPinIcon, DocumentMagnifyingGlassIcon, ExclamationTriangleIcon } from '@heroicons/react/24/solid';
 import { AddressData } from "@/types/d";
 import {CheckCircleIcon} from "lucide-react";
+import { fetchWithAuth } from '../lib/util/fetchWithAuth';
 
 export default function ClientPage() {
     const router = useRouter();
@@ -22,6 +23,7 @@ export default function ClientPage() {
     const [isLoading, setIsLoading] = useState(false);
     const [geoError, setGeoError] = useState('');
     const [isGeoLoading, setIsGeoLoading] = useState(true);
+    const BASE_URL = 'http://localhost:8080';
 
     // 브라우저 위치 정보 조회
     useEffect(() => {
@@ -124,9 +126,8 @@ export default function ClientPage() {
         });
 
         try {
-            const response = await fetch('http://localhost:8080/oauth/users/additional-info', {
+            const response = await fetchWithAuth(`${BASE_URL}/oauth/users/additional-info`, {
                 method: 'PATCH',
-                credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
                 },

--- a/frontend/app/lib/util/fetchWithAuth.js
+++ b/frontend/app/lib/util/fetchWithAuth.js
@@ -1,0 +1,64 @@
+const refreshAccessToken = async () => {
+    try {
+        const response = await fetch('http://localhost:8080/oauth/token/refresh', {
+            method: 'POST',
+            credentials: 'include', // 쿠키 포함
+        });
+
+        const data = await response.json();
+
+        if (!response.ok || !data.data.access_token) {
+            throw new Error('리프레시 토큰이 유효하지 않습니다.');
+        }
+
+        // 새 액세스 토큰을 세션 스토리지에 저장
+        sessionStorage.setItem('access_token', data.data.access_token);
+
+        return data.data.access_token; // 새 액세스 토큰 반환
+    } catch (error) {
+        console.error('토큰 갱신 실패:', error);
+        sessionStorage.removeItem('access_token'); // 만료된 액세스 토큰 제거
+        window.location.href = '/login'; // 로그인 페이지로 리디렉션
+    }
+};
+
+const fetchWithAuth = async (url, options = {}, retry = true) => {
+    try {
+        // 세션 스토리지에서 액세스 토큰 가져오기
+        const accessToken = sessionStorage.getItem('access_token');
+
+        // Authorization 헤더 추가
+        const headers = {
+            ...options.headers,
+            'Authorization': `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+        };
+
+        const response = await fetch(url, {
+            ...options,
+            headers,
+        });
+
+        if (response.status === 401 || response.status === 403) {
+            if (retry) {
+                console.warn('액세스 토큰 만료, 리프레시 토큰으로 갱신 시도 중...');
+
+                // 새 액세스 토큰 발급
+                const newAccessToken = await refreshAccessToken();
+
+                if (newAccessToken) {
+                    // 재시도: 새 액세스 토큰으로 요청 재전송
+                    return fetchWithAuth(url, options, false);
+                }
+            }
+            throw new Error('인증 실패: 다시 로그인하세요.');
+        }
+
+        return response;
+    } catch (error) {
+        console.error('API 호출 오류:', error);
+        throw error;
+    }
+};
+
+export { fetchWithAuth };

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -80,6 +80,9 @@ export default function LoginPage() {
                     console.log('백엔드 응답:', data);
                     console.log('추가정보필요 플래그:', data.data?.additionalInfoRequired);
 
+                    // 세션 스토리지에 액세스 토큰 저장
+                    sessionStorage.setItem('access_token', data.data.access_token);
+
                     // 🔥 추가 정보 필요 여부 체크
                     if (data.data?.additionalInfoRequired) {
                         sessionStorage.setItem('requiresAdditionalInfo', 'true');

--- a/frontend/app/test/page.tsx
+++ b/frontend/app/test/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import {useEffect, useState} from "react";
+import {fetchWithAuth} from "@/app/lib/util/fetchWithAuth";
+
+const ProtectedPage = () => {
+    const [data, setData] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchProtectedResource = async () => {
+            try {
+                // fetchWithAuth를 사용하여 보호된 리소스 요청
+                const response = await fetchWithAuth("http://localhost:8080/protected-resource", {
+                    method: "GET",
+                    credentials: 'include'
+                });
+
+                if (!response.ok) {
+                    throw new Error("요청 실패: " + response.status);
+                }
+
+                const result = await response.text();
+                setData(result);
+            } catch (err: any) {
+                setError(err.message);
+            }
+        };
+
+        fetchProtectedResource();
+    }, []);
+
+    return (
+        <div>
+            <h1>보호된 페이지</h1>
+            {error && <p style={{ color: "red" }}>오류: {error}</p>}
+            {data && <p>응답 데이터: {data}</p>}
+        </div>
+    );
+};
+
+export default ProtectedPage;


### PR DESCRIPTION
## ✅ Check List
- 코드에 주석 추가 완료
- 기존 액세스 토큰만 이용하던 것에서 리프레시 토큰을 활용해 액세스 토큰을 재발급 받을 수 있도록 변경
- 소셜 로그인, 회원가입 -> 로그인 후에 액세스 토큰을 응답 바디로 넘겨서 세션 스토리지에 저장 (만료 시간 1시간)
- 이후엔 쿠키에 있는 리프레시 토큰으로 액세스 토큰 재발급 후 자동으로 헤더에 설정하고 세션 스토리지에 저장해 줌

+ 📸 Screenshot or Test Result

## 🔍 Test 
<img width="682" alt="스크린샷 2025-03-11 오후 7 59 39" src="https://github.com/user-attachments/assets/63bea9d9-ff81-4574-b50c-09b7d3886cbe" />
<img width="674" alt="스크린샷 2025-03-11 오후 7 59 50" src="https://github.com/user-attachments/assets/bd30204e-fb8d-4f26-b60b-ec2f42639f1a" />

- 소셜 로그인 후에 액세스 토큰은 응답 바디로 넘어가 세션 스토리지에, 리프레시 토큰은 쿠키에 저장

<img width="966" alt="스크린샷 2025-03-11 오후 8 30 32" src="https://github.com/user-attachments/assets/5291bfdf-e8cf-45d7-8be6-210695618d62" />

![스크린샷 2025-03-11 오후 8 54 26](https://github.com/user-attachments/assets/5454f7a3-f5ea-47fe-837a-2adbc32c38df)

![스크린샷 2025-03-11 오후 9 07 40](https://github.com/user-attachments/assets/7bc4a8bc-9343-4daa-bf10-a6dd347555c4)

- 액세스 토큰은 헤더로 전송하면 필터가 정보를 반환해 줌, 예시 컨트롤러를 생성해서 테스트 했습니다 이전과 동일하게 사용하시면 됩니다 (로그인 애노테이션 + 커스텀유저디테일)

![스크린샷 2025-03-11 오후 12 39 56](https://github.com/user-attachments/assets/fa867853-668c-4e1f-b2d4-0a7a44e82918)

- 구글 필터는 헤더가 있는 내용에만 적용되므로 일반 로그인은 기존대로 JWT 적용됩니다

![스크린샷 2025-03-12 오전 9 48 23](https://github.com/user-attachments/assets/6304fb37-8007-410c-ab62-c77713e74b68)
![스크린샷 2025-03-12 오전 9 41 48](https://github.com/user-attachments/assets/97e452d2-6c66-41bd-a595-4f98cd5d9bff)
![스크린샷 2025-03-12 오전 9 42 01](https://github.com/user-attachments/assets/d247a251-ab9a-4f8d-8948-f5be55b783ba)
![스크린샷 2025-03-12 오전 9 42 14](https://github.com/user-attachments/assets/4685b9de-ce33-4f9c-a463-109b7c2c9397)

- 세션 스토리지에 저장된 액세스 토큰 없애고 헤더 없이 전송했을 때, 자동으로 refresh로 전송이 되어서 토큰 재발급 프로세스 진행

![스크린샷 2025-03-12 오전 9 45 45](https://github.com/user-attachments/assets/1343eef0-3f24-480f-a4e2-6e2990eb137d)
![스크린샷 2025-03-12 오전 9 45 48](https://github.com/user-attachments/assets/d4a67007-82d4-4bea-ad59-4fd386a1ceca)

## 🔗 Related Issues 
[[FEAT] 리프레시 토큰으로 액세스 토큰 재발급 #51 ](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/51)

## 📝 Note (주의 사항) 
프론트엔드에서 fetch 대신 fetchWithAuth 함수 사용하시면 자동으로 재발급 됩니다 
확인하시고 변경해 주세요!