### PR TITLE
✨ feat: 헤더에 프로필이미지 조회하도록 추가 #88

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/controller/UserController.java
@@ -8,6 +8,8 @@ import com.snackoverflow.toolgether.domain.user.entity.User;
 import com.snackoverflow.toolgether.domain.user.service.UserService;
 import com.snackoverflow.toolgether.domain.user.service.VerificationService;
 import com.snackoverflow.toolgether.global.dto.RsData;
+import com.snackoverflow.toolgether.global.filter.CustomUserDetails;
+import com.snackoverflow.toolgether.global.filter.Login;
 import com.snackoverflow.toolgether.global.util.JwtUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -98,6 +100,19 @@ public class UserController {
                         "nickname", user.getNickname(),
                         "token", result.token()
                 )
+        );
+    }
+
+    @GetMapping("/profile")
+    public RsData<String> getProfile(
+            @Login CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        String profile = userService.getMyProfile(userId);
+        return new RsData<>(
+                "200-1",
+                "프로필 조회 성공",
+                profile
         );
     }
 

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/service/UserService.java
@@ -318,4 +318,10 @@ public class UserService {
     public List<User> getUsersWithoutReviewsSince(LocalDateTime date) {
         return userRepository.findUsersWithoutReviewsSince(date);
     }
+
+    public String getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        return user.getProfileImage() == null ? "" : user.getProfileImage();
+    }
 }


### PR DESCRIPTION
헤더에 프로필이미지가 존재하면 나오고 없으면 빈 이미지가 나오도록 수정했습니다.


+ 📸 Screenshot or Test Result

![asd](https://github.com/user-attachments/assets/8f4f09a2-a7a5-42ed-9151-f4a358f327cb)


## 🔗 Related Issues 
[[FEAT] 헤더에 프로필 이미지 조회되도록 추가 #88
](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/88)

## 📝 Note (주의 사항) 
프로필이미지 조회 시 마이페이지처럼 sns 계정이 아닌 일반 계정에서 fetchWithAuth 요청시 오류가 있어 fetchHelper로 사용자 분류별로 요청을 다르게 진행하는데, 이후 수정이 필요합니다.