### PR TITLE
사용되지 않는 이미지 정리 스케쥴러추가

### DIFF
--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/postimage/repository/PostImageRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/postimage/repository/PostImageRepository.java
@@ -2,6 +2,7 @@ package com.snackoverflow.toolgether.domain.postimage.repository;
 
 import com.snackoverflow.toolgether.domain.postimage.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +13,7 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
     List<PostImage> findByPostId(Long postId);
     void deleteByPostId(Long postId);
+
+    @Query("SELECT pi.imageUrl FROM PostImage pi")
+    List<String> findAllImageUrl();
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/domain/user/repository/UserRepository.java
@@ -29,4 +29,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u LEFT JOIN Review r ON r.reviewee = u AND r.createdAt >= :date WHERE r.reviewee IS NULL")
     List<User> findUsersWithoutReviewsSince(LocalDateTime date);
+
+    @Query("SELECT u.profileImage FROM User u WHERE u.profileImage IS NOT NULL")
+    List<String> findAllProfileImageUrl();
 }

--- a/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3OrphanedImageCleanupService.java
+++ b/backend/src/main/java/com/snackoverflow/toolgether/global/util/s3/S3OrphanedImageCleanupService.java
@@ -1,0 +1,60 @@
+package com.snackoverflow.toolgether.global.util.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.snackoverflow.toolgether.domain.postimage.repository.PostImageRepository;
+import com.snackoverflow.toolgether.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3OrphanedImageCleanupService {
+
+    private final AmazonS3Client amazonS3Client;
+    private final PostImageRepository postImageRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Scheduled(cron = "0 0 3 1 1,4,7,10 *")
+    public void cleanupOrphanedImages() {
+        log.info("S3 버킷 orphaned 이미지 삭제 스케줄러 시작");
+
+        List<String> dbPostImageUrls = postImageRepository.findAllImageUrl();
+
+        List<String> dbProfileImageUrls = userRepository.findAllProfileImageUrl();
+
+        List<String> allDbImageUrls = Stream.concat(dbPostImageUrls.stream(), dbProfileImageUrls.stream())
+                .collect(Collectors.toList());
+
+        ListObjectsV2Result result = amazonS3Client.listObjectsV2(bucketName);
+        List<S3ObjectSummary> objects = result.getObjectSummaries();
+
+        int deletedCount = 0;
+
+        for (S3ObjectSummary object : objects) {
+            String s3ObjectKey = object.getKey();
+            String s3ImageUrl = amazonS3Client.getUrl(bucketName, s3ObjectKey).toString();
+
+            if (!allDbImageUrls.contains(s3ImageUrl)) {
+                log.info("사용되지 않는 S3 버킷 내 이미지 URL: {}", s3ImageUrl);
+                s3Service.delete(s3ImageUrl);
+                deletedCount++;
+            }
+        }
+
+        log.info("S3 버킷에서 사용되지 않는 이미지 삭제 스케줄러 종료. 총 {}개의 이미지 삭제됨", deletedCount);
+    }
+}


### PR DESCRIPTION
✨ 구현 내용
1월부터 3개월 주기로 1일 3시에 post 및 user 엔티티에서 사용되지 않는 이미지 삭제 스케쥴러

+ 📸 Screenshot or Test Result
![asdd](https://github.com/user-attachments/assets/1902b6a2-ba0d-4b22-8dac-7105ac5cfbef)
![asdasdad](https://github.com/user-attachments/assets/891ad259-01da-43dc-aee7-c28d501e9ac4)

## 🔗 Related Issues 
[[FEAT] 사용되지 않는 이미지 삭제 스케쥴러 추가 #105](https://github.com/prgrms-be-devcourse/NBE4-5-2-Team02/issues/105)

